### PR TITLE
Released version 1.2

### DIFF
--- a/class-wc-gateway-laskuhari.php
+++ b/class-wc-gateway-laskuhari.php
@@ -118,6 +118,23 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                 <?php if( $this->verkkolasku_kaytossa ): ?><option value="verkkolasku"<?php echo ($laskutustapa == "verkkolasku" ? ' selected' : ''); ?>><?php echo __('Verkkolasku', 'laskuhari'); ?></option><?php endif; ?>
                 <?php if( $this->kirjelasku_kaytossa ): ?><option value="kirje"<?php echo ($laskutustapa == "kirje" ? ' selected' : ''); ?>><?php echo __('Kirje', 'laskuhari'); ?></option><?php endif; ?>
             </select>
+            <?php
+            if( is_admin() ) {
+                $invoicing_email = get_laskuhari_meta( $order_id, '_laskuhari_email', true );
+                if( ! $invoicing_email ) {
+                    $order = wc_get_order( $order_id );
+                    if( $order ) {
+                        $invoicing_email = $order->get_billing_email();
+                    }
+                }
+                ?>
+                <div id="laskuhari-sahkoposti-tiedot" style="<?php echo ($laskutustapa == "email" ? '' : 'display: none;'); ?>">
+                    <div class="laskuhari-caption"><?php echo __( 'Sähköpostiosoite', 'laskuhari' ); ?>:</div>
+                    <input type="text" id="laskuhari-email" value="<?php echo esc_attr( $invoicing_email ); ?>" name="laskuhari-email" /><br />
+                </div>
+                <?php
+                }
+            ?>
             <div id="laskuhari-verkkolasku-tiedot" style="<?php echo ($laskutustapa == "verkkolasku" ? '' : 'display: none;'); ?>">
                 <?php
                 if( ! is_checkout() || ! laskuhari_vat_id_custom_field_exists() ) {

--- a/class-wc-gateway-laskuhari.php
+++ b/class-wc-gateway-laskuhari.php
@@ -108,8 +108,8 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
     }
 
     public function lahetystapa_lomake( $order_id = false ) {
-        $laskutustapa = get_post_meta( $order_id, '_laskuhari_laskutustapa', true );
-        $valittaja = get_post_meta( $order_id, '_laskuhari_valittaja', true );
+        $laskutustapa = get_laskuhari_meta( $order_id, '_laskuhari_laskutustapa', true );
+        $valittaja = get_laskuhari_meta( $order_id, '_laskuhari_valittaja', true );
         ?>
             <div id="laskuhari-lahetystapa-lomake">
             <select id="laskuhari-laskutustapa" class="laskuhari-pakollinen" name="laskuhari-laskutustapa">
@@ -119,10 +119,16 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                 <?php if( $this->kirjelasku_kaytossa ): ?><option value="kirje"<?php echo ($laskutustapa == "kirje" ? ' selected' : ''); ?>><?php echo __('Kirje', 'laskuhari'); ?></option><?php endif; ?>
             </select>
             <div id="laskuhari-verkkolasku-tiedot" style="<?php echo ($laskutustapa == "verkkolasku" ? '' : 'display: none;'); ?>">
-                <div class="laskuhari-caption"><?php echo __( 'Y-tunnus', 'laskuhari' ); ?>:</div>
-                <input type="text" class="verkkolasku-pakollinen" value="<?php echo esc_attr( get_post_meta( $order_id, '_laskuhari_ytunnus', true ) ); ?>" id="laskuhari-ytunnus" name="laskuhari-ytunnus" /><br />
+                <?php
+                if( ! is_checkout() || ! laskuhari_vat_id_custom_field_exists() ) {
+                    ?>
+                    <div class="laskuhari-caption"><?php echo __( 'Y-tunnus', 'laskuhari' ); ?>:</div>
+                    <input type="text" class="verkkolasku-pakollinen" value="<?php echo esc_attr( get_laskuhari_meta( $order_id, '_laskuhari_ytunnus', true ) ); ?>" id="laskuhari-ytunnus" name="laskuhari-ytunnus" /><br />
+                    <?php
+                }
+                ?>
                 <div class="laskuhari-caption"><?php echo __( 'Verkkolaskuosoite / OVT', 'laskuhari' ); ?>:</div>
-                <input type="text" id="laskuhari-verkkolaskuosoite" value="<?php echo esc_attr( get_post_meta( $order_id, '_laskuhari_verkkolaskuosoite', true ) ); ?>" name="laskuhari-verkkolaskuosoite" /><br />
+                <input type="text" id="laskuhari-verkkolaskuosoite" value="<?php echo esc_attr( get_laskuhari_meta( $order_id, '_laskuhari_verkkolaskuosoite', true ) ); ?>" name="laskuhari-verkkolaskuosoite" /><br />
                 <div class="laskuhari-caption"><?php echo __( 'Verkkolaskuoperaattori', 'laskuhari' ); ?>:</div>
                 <select id="laskuhari-valittaja" name="laskuhari-valittaja">
                     <option value="">-- <?php echo __( 'Valitse verkkolaskuoperaattori', 'laskuhari' ); ?> ---</option>
@@ -167,6 +173,13 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
         <?php
     }
 
+    public function viitteenne_lomake( $order_id = false ) {
+        ?>
+        <div class="laskuhari-caption"><?php echo __( 'Viitteenne', 'laskuhari' ); ?> (<?php echo __( 'valinnainen', 'laskuhari' ); ?>):</div>
+        <input type="text" id="laskuhari-viitteenne" value="<?php echo esc_attr( get_laskuhari_meta( $order_id, '_laskuhari_viitteenne', true ) ); ?>" name="laskuhari-viitteenne" />
+        <?php
+    }
+
     public function payment_fields() {
         $description = $this->get_description();
         if ( $description ) {
@@ -174,10 +187,7 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
         }
 
         $this->lahetystapa_lomake();
-        ?>
-        <div class="laskuhari-caption"><?php echo __( 'Viitteenne', 'laskuhari' ); ?> (<?php echo __( 'valinnainen', 'laskuhari' ); ?>):</div>
-        <input type="text" id="laskuhari-viitteenne" name="laskuhari-viitteenne" />
-        <?php
+        $this->viitteenne_lomake();
     }
 
     /**

--- a/js/admin.js
+++ b/js/admin.js
@@ -67,6 +67,7 @@ function laskuhari_admin_action( action ) {
 	var verkkolaskuosoite = $('#laskuhari-verkkolaskuosoite').val();
 	var valittajatunnus   = $('#laskuhari-valittaja').val();
 	var viitteenne        = $('#laskuhari-viitteenne').val();
+	var email             = $('#laskuhari-email').val();
 
 	window.location.href = urli+
 		'laskuhari='+action+
@@ -75,5 +76,6 @@ function laskuhari_admin_action( action ) {
 		'&laskuhari-ytunnus='+encodeURIComponent(ytunnus)+
 		'&laskuhari-verkkolaskuosoite='+encodeURIComponent(verkkolaskuosoite)+
 		'&laskuhari-valittaja='+encodeURIComponent(valittajatunnus)+
-		'&laskuhari-viitteenne='+encodeURIComponent(viitteenne);
+		'&laskuhari-viitteenne='+encodeURIComponent(viitteenne)+
+		'&laskuhari-email='+encodeURIComponent(email);
 }

--- a/js/admin.js
+++ b/js/admin.js
@@ -66,6 +66,7 @@ function laskuhari_admin_action( action ) {
 	var ytunnus           = $('#laskuhari-ytunnus').val();
 	var verkkolaskuosoite = $('#laskuhari-verkkolaskuosoite').val();
 	var valittajatunnus   = $('#laskuhari-valittaja').val();
+	var viitteenne        = $('#laskuhari-viitteenne').val();
 
 	window.location.href = urli+
 		'laskuhari='+action+
@@ -73,5 +74,6 @@ function laskuhari_admin_action( action ) {
 		'&laskuhari-maksuehto='+encodeURIComponent(maksuehto)+
 		'&laskuhari-ytunnus='+encodeURIComponent(ytunnus)+
 		'&laskuhari-verkkolaskuosoite='+encodeURIComponent(verkkolaskuosoite)+
-		'&laskuhari-valittaja='+encodeURIComponent(valittajatunnus);
+		'&laskuhari-valittaja='+encodeURIComponent(valittajatunnus)+
+		'&laskuhari-viitteenne='+encodeURIComponent(viitteenne);
 }

--- a/js/public.js
+++ b/js/public.js
@@ -1,13 +1,20 @@
 var laskuhari_viime_maksutapa = false;
 
 (function($) {
-    function laskuhari_tarkista_verkkolaskuosoite() {
+    function laskuhari_changed_send_method() {
         if( $("#laskuhari-laskutustapa").val() == "verkkolasku" ) {
             $("#laskuhari-verkkolasku-tiedot").show();
             $(".verkkolasku-pakollinen").attr("required", true);
         } else {
             $("#laskuhari-verkkolasku-tiedot").hide();
             $(".verkkolasku-pakollinen").attr("required", false);
+        }
+        if( $("#laskuhari-laskutustapa").val() == "email" ) {
+            $("#laskuhari-sahkoposti-tiedot").show();
+            $("#laskuhari-email").attr("required", true);
+        } else {
+            $("#laskuhari-sahkoposti-tiedot").hide();
+            $("#laskuhari-email").attr("required", false);
         }
     }
     function laskuhari_tarkista_laskutustapa(){
@@ -44,7 +51,7 @@ var laskuhari_viime_maksutapa = false;
             }
         });
         $("body").on("keyup change", "#laskuhari-laskutustapa", function() {
-            laskuhari_tarkista_verkkolaskuosoite();
+            laskuhari_changed_send_method();
         });
     });
 })(jQuery);

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -2128,6 +2128,8 @@ function laskuhari_send_invoice( $order, $bulk_action = false ) {
         $send_method = $info->send_method_fallback;
     }
 
+    $mihin = "";
+
     if( $send_method == "verkkolasku" ) {
         $verkkolaskuosoite = get_laskuhari_meta( $order_id, '_laskuhari_verkkolaskuosoite', true );
         $valittaja         = get_laskuhari_meta( $order_id, '_laskuhari_valittaja', true );
@@ -2135,6 +2137,7 @@ function laskuhari_send_invoice( $order, $bulk_action = false ) {
 
         $can_send = true;
         $miten    = "verkkolaskuna";
+        $mihin    = " osoitteeseen $verkkolaskuosoite ($valittaja)";
 
         $payload = [
             "lahetystapa" => "verkkolasku",
@@ -2162,6 +2165,7 @@ function laskuhari_send_invoice( $order, $bulk_action = false ) {
 
         $can_send   = true;
         $miten      = "sähköpostitse";
+        $mihin      = " osoitteeseen $email";
         $sendername = $sendername ? $sendername : "Laskutus";
 
         if( $email_message == "" ) {
@@ -2234,7 +2238,7 @@ function laskuhari_send_invoice( $order, $bulk_action = false ) {
             );
         }
 
-        $order->add_order_note( __( 'Lasku lähetetty ' . $miten, 'laskuhari' ) );
+        $order->add_order_note( __( 'Lasku lähetetty ' . $miten . $mihin, 'laskuhari' ) );
         update_post_meta( $order->get_id(), '_laskuhari_sent', 'yes' );
 
         if( ! is_laskuhari_allowed_order_status( $order->get_status() ) ) {

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1711,6 +1711,8 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
 
     laskuhari_update_payment_terms_meta( $order->get_id() );
 
+    $customer_id = apply_filters( 'laskuhari_customer_id', $order->get_user_id(), $order_id );
+
     $payload = [
         "ref" => "wc",
         "site" => $_SERVER['HTTP_HOST'],
@@ -1736,7 +1738,8 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
             "postinumero" => $customer['postcode'],
             "postitoimipaikka" => $customer['city'],
             "email" => $customer['email'],
-            "puhelin" => $customer['phone']
+            "puhelin" => $customer['phone'],
+            "asiakasnro" => $customer_id
         ],
         "toimitusosoite" => [
             "yritys" => $shippingdata['company'],

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1350,13 +1350,15 @@ function laskuhari_notices() {
 
     foreach ( $orders as $key => $notice ) {
         if( $notice != "" ) {
-            echo '<div class="notice notice-success is-dismissible"><p>Tilauksesta #' . esc_html( $notice ) . ' luotu lasku</p></div>';
+            $order = wc_get_order( $notice );
+            echo '<div class="notice notice-success is-dismissible"><p>Tilauksesta #' . esc_html( $order->get_order_number() ) . ' luotu lasku</p></div>';
         }
     }
 
     foreach ( $orders2 as $key => $notice ) {
         if( $notice != "" ) {
-            echo '<div class="notice notice-success is-dismissible"><p>Tilauksesta #' . esc_html( $notice ) . ' lähetetty lasku</p></div>';
+            $order = wc_get_order( $notice );
+            echo '<div class="notice notice-success is-dismissible"><p>Tilauksesta #' . esc_html( $order->get_order_number() ) . ' lähetetty lasku</p></div>';
         }
     }
 }

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -102,22 +102,37 @@ function laskuhari_json_flag() {
     return JSON_INVALID_UTF8_SUBSTITUTE;
 }
 
+function lh_create_select_box( $name, $options, $current = '' ) {
+    $html = '<select name="'.esc_attr( $name ).'">';
+    foreach( $options as $value => $text ) {
+        $html .= '<option value="'.esc_attr( $value ).'"';
+        if( $current === $value ) {
+            $html .= " selected";
+        }
+        $html .= '>'.esc_html( $text ).'</option>';
+    }
+    $html .= '</select>';
+    return $html;
+}
+
 add_action( 'restrict_manage_posts', 'display_admin_shop_order_laskuhari_filter' );
 function display_admin_shop_order_laskuhari_filter() {
     global $pagenow, $post_type;
 
     if( 'shop_order' === $post_type && 'edit.php' === $pagenow ) {
-        $current   = isset($_GET['filter_laskuhari_status']) ? $_GET['filter_laskuhari_status'] : '';
+        $current = isset( $_GET['filter_laskuhari_status'] ) ? $_GET['filter_laskuhari_status'] : '';
 
-        echo '<select name="filter_laskuhari_status">
-        <option value="">Laskuhari: ' . __('Kaikki ', 'laskuhari') . '</option>
-        <option value="ei_laskutettu"'.( $current == 'ei_laskutettu' ? ' selected' : '' ).'>Laskuhari: '.__('Ei laskutettu', 'laskuhari').'</option>
-        <option value="ei_laskutettu_kaikki"'.( $current == 'ei_laskutettu_kaikki' ? ' selected' : '' ).'>Laskuhari: '.__('Ei laskutettu (Kaikki)', 'laskuhari').'</option>
-        <option value="lasku_luotu"'.( $current == 'lasku_luotu' ? ' selected' : '' ).'>Laskuhari: '.__('Lasku luotu', 'laskuhari').'</option>
-        <option value="laskutettu"'.( $current == 'laskutettu' ? ' selected' : '' ).'>Laskuhari: '.__('Laskutettu', 'laskuhari').'</option>
-        <option value="maksettu"'.( $current == 'maksettu' ? ' selected' : '' ).'>Laskuhari: '.__('Maksettu', 'laskuhari').'</option>
-        <option value="ei_maksettu"'.( $current == 'ei_maksettu' ? ' selected' : '' ).'>Laskuhari: '.__('Ei maksettu', 'laskuhari').'</option>
-        </select>';
+        $options = [
+            ""                     => 'Laskuhari: ' . __( 'Kaikki', 'laskuhari' ),
+            "ei_laskutettu"        => 'Laskuhari: ' . __( 'Ei laskutettu', 'laskuhari' ),
+            "ei_laskutettu_kaikki" => 'Laskuhari: ' . __( 'Ei laskutettu (Kaikki)', 'laskuhari' ),
+            "lasku_luotu"          => 'Laskuhari: ' . __( 'Lasku luotu', 'laskuhari' ),
+            "laskutettu"           => 'Laskuhari: ' . __( 'Laskutettu', 'laskuhari' ),
+            "maksettu"             => 'Laskuhari: ' . __( 'Maksettu', 'laskuhari' ),
+            "ei_maksettu"          => 'Laskuhari: ' . __( 'Ei maksettu', 'laskuhari' )
+        ];
+
+        echo lh_create_select_box( "filter_laskuhari_status", $options, $current );
     }
 }
 

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1757,7 +1757,8 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
             "buyerPartyIdentifier" => $ytunnus
         ],
         "woocommerce" => [
-            "wc_order_id" => $order->get_id()
+            "wc_order_id" => $order->get_id(),
+            "wc_user_id" => $order->get_user_id()
         ]
     ];
 

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Laskuhari for WooCommerce
 Plugin URI: https://www.laskuhari.fi/woocommerce-laskutus
 Description: Lisää automaattilaskutuksen maksutavaksi WooCommerce-verkkokauppaan sekä mahdollistaa tilausten manuaalisen laskuttamisen
-Version: 1.1.2
+Version: 1.2
 Author: Datahari Solutions
 Author URI: https://www.datahari.fi
 License: GPLv2

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit; // Exit if accessed directly
 }
 
-$laskuhari_plugin_version = "1.1.1";
+$laskuhari_plugin_version = "1.2";
 
 $__laskuhari_api_query_count = 0;
 $__laskuhari_api_query_limit = 2;

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1828,7 +1828,7 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
         }
 
         if( $data[$sub.'total'] != 0 ) {
-            $yks_verollinen = round( $yht_verollinen / $data['quantity'], 2 );
+            $yks_verollinen = round( $yht_verollinen / $data['quantity'], 10 );
             $yks_veroton    = $yks_verollinen / ( 1 + $alv / 100 );
         } else {
             $yks_verollinen = 0;

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -831,7 +831,7 @@ function laskuhari_vat_number_fields() {
     ];
 }
 
-function laskuhari_ytunnus_kassalla() {
+function laskuhari_vat_id_at_checkout() {
     $vat_number_fields = laskuhari_vat_number_fields();
     foreach( $_REQUEST as $key => $value ) {
         foreach( $vat_number_fields as $field_name ) {
@@ -859,7 +859,7 @@ function laskuhari_einvoice_notices( $fields, $errors ) {
         if ( ! $_POST['laskuhari-laskutustapa'] ) {
             $errors->add( 'validation', __( 'Ole hyvä ja valitse laskutustapa' ) );
         }
-        if ( mb_strlen( laskuhari_ytunnus_kassalla() ) < 6 && $_POST['laskuhari-laskutustapa'] == "verkkolasku" ) {
+        if ( mb_strlen( laskuhari_vat_id_at_checkout() ) < 6 && $_POST['laskuhari-laskutustapa'] == "verkkolasku" ) {
             $errors->add( 'validation', __( 'Ole hyvä ja syötä y-tunnus verkkolaskun lähetystä varten' ) );
         }
     }
@@ -929,7 +929,7 @@ function get_laskuhari_meta( $order_id, $meta_key, $single = true ) {
 function laskuhari_update_order_meta( $order_id )  {
     laskuhari_update_payment_terms_meta( $order_id );
     
-    $ytunnus = laskuhari_ytunnus_kassalla();
+    $ytunnus = laskuhari_vat_id_at_checkout();
     if ( isset( $ytunnus ) ) {
         laskuhari_set_order_meta( $order_id, '_laskuhari_ytunnus', $ytunnus, true );
     }

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -947,6 +947,9 @@ function laskuhari_update_order_meta( $order_id )  {
     if ( isset( $_REQUEST['laskuhari-verkkolaskuosoite'] ) ) {
         laskuhari_set_order_meta( $order_id, '_laskuhari_verkkolaskuosoite', $_REQUEST['laskuhari-verkkolaskuosoite'], true );
     }
+    if ( isset( $_REQUEST['laskuhari-email'] ) ) {
+        laskuhari_set_order_meta( $order_id, '_laskuhari_email', $_REQUEST['laskuhari-email'], false );
+    }
     if ( isset( $_REQUEST['laskuhari-valittaja'] ) ) {
         laskuhari_set_order_meta( $order_id, '_laskuhari_valittaja', $_REQUEST['laskuhari-valittaja'], true );
     }
@@ -1288,7 +1291,7 @@ function laskuhari_back_url( $lh = false, $url = false ) {
         'laskuhari_luotu', 'laskuhari_success', 'laskuhari_lahetetty',
         'laskuhari_notice', 'laskuhari_send_invoice', 'laskuhari-laskutustapa',
         'laskuhari-maksuehto', 'laskuhari-ytunnus', 'laskuhari-verkkolaskuosoite',
-        'laskuhari-valittaja', 'laskuhari_action'
+        'laskuhari-valittaja', 'laskuhari_action', 'laskuhari-email'
     );
 
     $back = remove_query_arg(
@@ -1658,6 +1661,10 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
 
     if ( isset( $_REQUEST['laskuhari-viitteenne'] ) ) {
         laskuhari_set_order_meta( $order_id, '_laskuhari_viitteenne', $_REQUEST['laskuhari-viitteenne'], false );
+    }
+
+    if ( isset( $_REQUEST['laskuhari-email'] ) ) {
+        laskuhari_set_order_meta( $order_id, '_laskuhari_email', $_REQUEST['laskuhari-email'], false );
     }
 
     $prices_include_tax = get_post_meta( $order_id, '_prices_include_tax', true ) == 'yes' ? true : false;
@@ -2139,7 +2146,10 @@ function laskuhari_send_invoice( $order, $bulk_action = false ) {
             ]
         ];
     } else if( $send_method == "email" ) {
-        if( stripos( $customer['email'] , "@" ) === false ) {
+        $email = get_laskuhari_meta( $order_id, '_laskuhari_email', true );
+        $email = $email ? $email : $customer['email'];
+
+        if( stripos( $email , "@" ) === false ) {
             $error_notice = 'Virhe sähköpostilaskun lähetyksessä: sähköpostiosoite puuttuu tai on virheellinen';
             $order->add_order_note( $error_notice );
             if( function_exists( 'wc_add_notice' ) ) {
@@ -2160,7 +2170,7 @@ function laskuhari_send_invoice( $order, $bulk_action = false ) {
 
         $payload = [
             "lahetystapa" => "email",
-            "osoite"      => $customer['email'],
+            "osoite"      => $email,
             "aihe"        => "Lasku",
             "viesti"      => $email_message,
             "lahettaja"   => $sendername

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1796,6 +1796,12 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
     }
 
     $coupon_codes = $order->get_coupon_codes();
+
+    // remove coupons staring with an underscore
+    $coupon_codes = array_filter( $coupon_codes, function($v) {
+        return $v[0] !== '_';
+    } );
+
     $has_coupons = count( $coupon_codes ) > 0;
 
     $laskurivit = [];

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -398,20 +398,11 @@ function laskuhari_user_profile_additional_info( $user ) {
                 </td>
             </tr>';
         } elseif( "select" === $meta_field['type'] ) {
-            $options = '';
-            foreach( $meta_field['options'] as $id => $value ) {
-                $selected = ($id == $current_value ? ' selected' : '');
-                $options .= '<option value="' . esc_attr( $id ) . '"' . $selected . '>' . esc_html( $value ) . '</option>';
-            }
-
             echo '
             <tr>
                 <th>' . $meta_disp_name . '</th>
                 <td>
-                    <select name="' . $meta_field_name . '"
-                            id="' . $meta_field_name . '">
-                        '.$options.'
-                    </select><br />
+                    '.lh_create_select_box( $meta_field_name, $meta_field['options'], $current_value ).'<br />
                     <span class="description"></span>
                 </td>
             </tr>';

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1796,13 +1796,12 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
     }
 
     $coupon_codes = $order->get_coupon_codes();
+    $has_coupons = count( $coupon_codes ) > 0;
 
     // remove coupons staring with an underscore
     $coupon_codes = array_filter( $coupon_codes, function($v) {
         return $v[0] !== '_';
     } );
-
-    $has_coupons = count( $coupon_codes ) > 0;
 
     $laskurivit = [];
 
@@ -1893,8 +1892,10 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
     if( abs( round( $cart_discount, 2 ) ) > 0 ) {
         $discount_name = "Alennus";
 
-        if( $has_coupons ) {
-            if( count( $coupon_codes ) > 1 ) {
+        $coupon_count = count( $coupon_codes );
+
+        if( $coupon_count > 0 ) {
+            if( $coupon_count > 1 ) {
                 $discount_name = __( "Kupongit", "laskuhari" );
             } else {
                 $discount_name = __( "Kuponki", "laskuhari" );

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1699,8 +1699,14 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
     // summat
     $loppusumma         = $order->get_total();
     $toimitustapa       = $order->get_shipping_method();
-    $toimitusmaksu      = $order->get_total_shipping();
+    $toimitusmaksu      = $order->get_shipping_total();
     $toimitus_vero      = $order->get_shipping_tax();
+
+    // calculate shipping cost down to multiple decimals
+    // get_shipping_total returns rounded excluding tax
+    $toimitus_veropros  = round( $toimitus_vero / $toimitusmaksu, 2);
+    $toimitusmaksu      = round( $toimitusmaksu + $toimitus_vero, 2 ) / ( 1 + $toimitus_veropros );
+
     $cart_discount      = $order->get_discount_total();
     $cart_discount_tax  = $order->get_discount_tax();
 

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -882,7 +882,7 @@ function laskuhari_update_payment_terms_meta( $order_id ) {
     }
 }
 
-function laskuhari_reset_metadata( $order_id ) {
+function laskuhari_reset_order_metadata( $order_id ) {
     update_post_meta( $order_id, '_laskuhari_payment_status', "" );
     update_post_meta( $order_id, '_laskuhari_payment_status_name', "" );
     update_post_meta( $order_id, '_laskuhari_payment_status_id', "" );
@@ -1712,7 +1712,7 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
         $maksuehto = laskuhari_get_customer_payment_terms_default( $order->get_customer_id() );
     }
 
-    laskuhari_reset_metadata( $order->get_id() );
+    laskuhari_reset_order_metadata( $order->get_id() );
 
     update_post_meta( $order->get_id(), '_laskuhari_sent', false );
 

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -907,10 +907,14 @@ function get_laskuhari_meta( $order_id, $meta_key, $single = true ) {
     if( $post_meta ) {
         return $post_meta;
     }
-    if( ! $order = wc_get_order( $order_id ) ) {
+    if( $order = wc_get_order( $order_id ) ) {
+        $user_id = $order->get_user_id();
+    } elseif( is_checkout() ) {
+        $user_id = get_current_user_id();
+    } else {
         return false;
     }
-    return get_user_meta( $order->get_user_id(), $meta_key, $single );
+    return get_user_meta( $user_id, $meta_key, $single );
 }
 
 // Lisää tilauslomakkessa annetut lisätiedot metadataan

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -141,11 +141,13 @@ function laskuhari_custom_status_filter( $query ) {
     global $pagenow;
 
     $status_queries = [
-        "laskutettu" => [[
-            'key'     => '_laskuhari_sent',
-            'compare' => '=',
-            'value'   => "yes",
-        ]],
+        "laskutettu" => [
+            [
+                'key'     => '_laskuhari_sent',
+                'compare' => '=',
+                'value'   => "yes",
+            ]
+        ],
         "ei_laskutettu" => [
             'relation' => 'and',
             [
@@ -257,7 +259,6 @@ function laskuhari_custom_status_filter( $query ) {
         }
         $status_query = $status_queries[$_GET['filter_laskuhari_status']];
         $query->set( 'meta_query', $status_query );
-
     }
 
 }
@@ -303,37 +304,37 @@ function laskuhari_user_meta() {
             "type"  => "select",
             "options" => [
                 "" => "-- Valitse --",
-                "003723327487" => "Apix Messaging Oy (003723327487)",
-                "BAWCFI22" => "Basware Oyj (BAWCFI22)",
-                "003703575029" => "CGI (003703575029)",
+                "003723327487"    => "Apix Messaging Oy (003723327487)",
+                "BAWCFI22"        => "Basware Oyj (BAWCFI22)",
+                "003703575029"    => "CGI (003703575029)",
                 "885790000000418" => "HighJump AS (885790000000418)",
-                "INEXCHANGE" => "InExchange Factorum AB (INEXCHANGE)",
-                "EXPSYS" => "Lexmark Expert Systems AB (EXPSYS)",
-                "003708599126" => "Liaison Technologies Oy (003708599126)",
-                "003721291126" => "Maventa (003721291126)",
-                "003726044706" => "Netbox Finland Oy (003726044706)",
-                "E204503" => "OpusCapita Solutions Oy (E204503)",
-                "003723609900" => "Pagero (003723609900)",
-                "PALETTE" => "Palette Software (PALETTE)",
-                "003710948874" => "Posti Messaging Oy (003710948874)",
-                "003701150617" => "PostNord Strålfors Oy (003701150617)",
-                "003714377140" => "Ropo Capital Oy (003714377140)",
-                "003703575029" => "Telia (003703575029)",
-                "003701011385" => "Tieto Oyj (003701011385)",
+                "INEXCHANGE"      => "InExchange Factorum AB (INEXCHANGE)",
+                "EXPSYS"          => "Lexmark Expert Systems AB (EXPSYS)",
+                "003708599126"    => "Liaison Technologies Oy (003708599126)",
+                "003721291126"    => "Maventa (003721291126)",
+                "003726044706"    => "Netbox Finland Oy (003726044706)",
+                "E204503"         => "OpusCapita Solutions Oy (E204503)",
+                "003723609900"    => "Pagero (003723609900)",
+                "PALETTE"         => "Palette Software (PALETTE)",
+                "003710948874"    => "Posti Messaging Oy (003710948874)",
+                "003701150617"    => "PostNord Strålfors Oy (003701150617)",
+                "003714377140"    => "Ropo Capital Oy (003714377140)",
+                "003703575029"    => "Telia (003703575029)",
+                "003701011385"    => "Tieto Oyj (003701011385)",
                 "885060259470028" => "Tradeshift (885060259470028)",
-                "HELSFIHH" => "Aktia (HELSFIHH)",
-                "DABAFIHH" => "Danske Bank (DABAFIHH)",
-                "DNBAFIHX" => "DNB (DNBAFIHX)",
-                "HANDFIHH" => "Handelsbanken (HANDFIHH)",
-                "NDEAFIHH" => "Nordea Pankki (NDEAFIHH)",
-                "ITELFIHH" => "Oma Säästöpankki (ITELFIHH)",
-                "OKOYFIHH" => "Osuuspankit (OKOYFIHH)",
-                "OKOYFIHH" => "Pohjola Pankki (OKOYFIHH)",
-                "POPFFI22" => "POP Pankki  (POPFFI22)",
-                "SBANFIHH" => "S-Pankki (SBANFIHH)",
-                "TAPIFI22" => "LähiTapiola (TAPIFI22)",
-                "ITELFIHH" => "Säästöpankit (ITELFIHH)",
-                "AABAFI22" => "Ålandsbanken (AABAFI22)",
+                "HELSFIHH"        => "Aktia (HELSFIHH)",
+                "DABAFIHH"        => "Danske Bank (DABAFIHH)",
+                "DNBAFIHX"        => "DNB (DNBAFIHX)",
+                "HANDFIHH"        => "Handelsbanken (HANDFIHH)",
+                "NDEAFIHH"        => "Nordea Pankki (NDEAFIHH)",
+                "ITELFIHH"        => "Oma Säästöpankki (ITELFIHH)",
+                "OKOYFIHH"        => "Osuuspankit (OKOYFIHH)",
+                "OKOYFIHH"        => "Pohjola Pankki (OKOYFIHH)",
+                "POPFFI22"        => "POP Pankki  (POPFFI22)",
+                "SBANFIHH"        => "S-Pankki (SBANFIHH)",
+                "TAPIFI22"        => "LähiTapiola (TAPIFI22)",
+                "ITELFIHH"        => "Säästöpankit (ITELFIHH)",
+                "AABAFI22"        => "Ålandsbanken (AABAFI22)",
             ]
         )
     );

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1690,10 +1690,10 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
     $cart_discount      = $order->get_discount_total();
     $cart_discount_tax  = $order->get_discount_tax();
 
-    $viitteenne        = get_post_meta( $order->get_id(), '_laskuhari_viitteenne', true );
-    $ytunnus           = get_post_meta( $order->get_id(), '_laskuhari_ytunnus', true );
-    $verkkolaskuosoite = get_post_meta( $order->get_id(), '_laskuhari_verkkolaskuosoite', true );
-    $valittaja         = get_post_meta( $order->get_id(), '_laskuhari_valittaja', true );
+    $viitteenne        = get_laskuhari_meta( $order->get_id(), '_laskuhari_viitteenne', true );
+    $ytunnus           = get_laskuhari_meta( $order->get_id(), '_laskuhari_ytunnus', true );
+    $verkkolaskuosoite = get_laskuhari_meta( $order->get_id(), '_laskuhari_verkkolaskuosoite', true );
+    $valittaja         = get_laskuhari_meta( $order->get_id(), '_laskuhari_valittaja', true );
 
     if( isset( $_REQUEST['laskuhari-maksuehto'] ) && is_admin() ) {
         $maksuehto = $_REQUEST['laskuhari-maksuehto'];
@@ -2073,9 +2073,9 @@ function laskuhari_send_invoice( $order, $bulk_action = false ) {
     }
 
     if( $send_method == "verkkolasku" ) {
-        $verkkolaskuosoite = get_post_meta( $order_id, '_laskuhari_verkkolaskuosoite', true );
-        $valittaja         = get_post_meta( $order_id, '_laskuhari_valittaja', true );
-        $ytunnus           = get_post_meta( $order_id, '_laskuhari_ytunnus', true );
+        $verkkolaskuosoite = get_laskuhari_meta( $order_id, '_laskuhari_verkkolaskuosoite', true );
+        $valittaja         = get_laskuhari_meta( $order_id, '_laskuhari_valittaja', true );
+        $ytunnus           = get_laskuhari_meta( $order_id, '_laskuhari_ytunnus', true );
 
         $can_send = true;
         $miten    = "verkkolaskuna";

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -808,7 +808,7 @@ function laskuhari_handle_bulk_actions( $redirect_to, $action, $order_ids ) {
 
         if( ! is_laskuhari_allowed_order_status( $order_status ) ) {
             $data = array();
-            $data["notice"][] = __( 'Tilausten tulee olla Käsittelyssä-tilassa, ennen kuin ne voidaan laskuttaa.', 'laskuhari' );
+            $data["notice"][] = __( 'Tilausten tulee olla Käsittelyssä- tai Valmis-tilassa, ennen kuin ne voidaan laskuttaa.', 'laskuhari' );
             return laskuhari_back_url( $data, $redirect_to );
         }
     }


### PR DESCRIPTION
- save customer e-invoice details to user meta …
- allow editing of customer e-invoice details in user meta
- detect custom business ID field and don't ask for it separately if custom field exists
- allow adding reference to invoice when creating from admin panel
- fixed e-invoice field validation during checkout
- use get_user_meta instead of get_the_author_meta for consistency
- added capability to filter orders based on invoicing status
- allow creating invoice also in completed status
- added ability to send email invoice from admin panel to custom address
- improved invoice row and sum calculations