### PR TITLE
Released version 1.3

### DIFF
--- a/class-wc-gateway-laskuhari.php
+++ b/class-wc-gateway-laskuhari.php
@@ -503,13 +503,6 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                 'label'             => __( 'Hyväksy laskutus-maksutapa, jos tuote on virtuaalinen', 'laskuhari' ),
                 'type'              => 'checkbox',
                 'default'           => 'yes'
-            ),
-            'enforce_ssl' => array(
-                'title'       => __( 'Vahvista SSL', 'laskuhari' ),
-                'label'       => __( 'Vahvista SSL-yhteys Laskuharin rajapintaan (suositellaan)', 'laskuhari' ),
-                'type'        => 'checkbox',
-                'description' => 'Mikäli pois käytöstä SSL_VERIFYHOST = 0, SSL_VERIFYPEER = FALSE',
-                'default'     => 'yes'
             )
         );
     }

--- a/class-wc-gateway-laskuhari.php
+++ b/class-wc-gateway-laskuhari.php
@@ -152,9 +152,9 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
             <div id="laskuhari-lahetystapa-lomake">
             <select id="laskuhari-laskutustapa" class="laskuhari-pakollinen" name="laskuhari-laskutustapa">
                 <option value="">-- <?php echo __('Valitse laskutustapa', 'laskuhari'); ?> --</option>
-                <?php if( $this->email_lasku_kaytossa ): ?><option value="email"<?php echo ($laskutustapa == "email" ? ' selected' : ''); ?>><?php echo __('Sähköposti', 'laskuhari'); ?></option><?php endif; ?>
-                <?php if( $this->verkkolasku_kaytossa ): ?><option value="verkkolasku"<?php echo ($laskutustapa == "verkkolasku" ? ' selected' : ''); ?>><?php echo __('Verkkolasku', 'laskuhari'); ?></option><?php endif; ?>
-                <?php if( $this->kirjelasku_kaytossa ): ?><option value="kirje"<?php echo ($laskutustapa == "kirje" ? ' selected' : ''); ?>><?php echo __('Kirje', 'laskuhari'); ?></option><?php endif; ?>
+                <?php if( $this->email_lasku_kaytossa || is_admin() ): ?><option value="email"<?php echo ($laskutustapa == "email" ? ' selected' : ''); ?>><?php echo __('Sähköposti', 'laskuhari'); ?></option><?php endif; ?>
+                <?php if( $this->verkkolasku_kaytossa || is_admin() ): ?><option value="verkkolasku"<?php echo ($laskutustapa == "verkkolasku" ? ' selected' : ''); ?>><?php echo __('Verkkolasku', 'laskuhari'); ?></option><?php endif; ?>
+                <?php if( $this->kirjelasku_kaytossa || is_admin() ): ?><option value="kirje"<?php echo ($laskutustapa == "kirje" ? ' selected' : ''); ?>><?php echo __('Kirje', 'laskuhari'); ?></option><?php endif; ?>
             </select>
             <?php
             if( is_admin() ) {

--- a/class-wc-gateway-laskuhari.php
+++ b/class-wc-gateway-laskuhari.php
@@ -485,7 +485,7 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                 'class'             => 'wc-enhanced-select',
                 'css'               => 'width: 450px;',
                 'default'           => '',
-                'description'       => __( 'Tällä toiminnolla voit lähettää esim. verkkomaksuista laskun asiakkaalle kuittina maksusta (lähetetään vain jos automaattinen lähetys on käytössä)', 'laskuhari' ),
+                'description'       => __( 'Tällä toiminnolla voit lähettää esim. verkkomaksuista laskun asiakkaalle kuittina maksusta (lähetetään tilausvahvistuksen liitteenä)', 'laskuhari' ),
                 'options'           => $payment_methods,
                 'desc_tip'          => true,
                 'custom_attributes' => array(
@@ -495,8 +495,8 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
             'invoice_email_text_for_other_payment_methods' => array(
                 'title'       => __( 'Laskuviesti (muu maksutapa)', 'laskuhari' ),
                 'type'        => 'textarea',
-                'description' => __( 'Viesti, joka lähetetään saatetekstinä sähköpostilaskun ohessa, kun tilaus on maksettu muuta maksutapaa käyttäen', 'laskuhari' ),
-                'default'     => __( 'Kiitos tilauksestasi. Liitteenä laskukopio kuittina tilaamistasi tuotteista.', 'laskuhari' ),
+                'description' => __( 'Teksti, joka lisätään tilausvahvistusviestiin, kun tilaus on maksettu muuta maksutapaa käyttäen', 'laskuhari' ),
+                'default'     => __( 'Liitteenä laskukopio kuittina tilaamistasi tuotteista.', 'laskuhari' ),
                 'desc_tip'    => true,
             ),
             'salli_laskutus_erikseen' => array(

--- a/class-wc-gateway-laskuhari.php
+++ b/class-wc-gateway-laskuhari.php
@@ -500,9 +500,9 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
         if ( ! $this->enable_for_virtual && ! $needs_shipping ) {
             return false;
         }
-        
+
         $current_user = wp_get_current_user();
-        
+
         // Tarkista käyttäjän laskutusasiakas-tieto
         $can_use_billing = get_the_author_meta( "laskuhari_laskutusasiakas", $current_user->ID ) !== "yes";
         $can_use_billing = apply_filters( "laskuhari_customer_can_use_billing", $can_use_billing, $current_user->ID );
@@ -510,7 +510,7 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
         if( $this->salli_laskutus_erikseen && $can_use_billing ) {
             return false;
         }
-        
+
         // Check methods
         if ( ! empty( $this->enable_for_methods ) && $needs_shipping ) {
 

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -846,10 +846,12 @@ function laskuhari_handle_bulk_actions( $redirect_to, $action, $order_ids ) {
     if( ! is_admin() ) {
         return false;
     }
-    
+
     if ( $action !== 'laskuhari-batch-send' ) {
         return $redirect_to;
     }
+
+    $send = apply_filters( "laskuhari_bulk_action_send", true, $order_ids );
 
     $data = array();
 
@@ -871,10 +873,10 @@ function laskuhari_handle_bulk_actions( $redirect_to, $action, $order_ids ) {
     }
 
     foreach( $_GET['post'] as $order_id ) {
-        $lh     = laskuhari_process_action( $order_id, true, true );
+        $lh     = laskuhari_process_action( $order_id, $send, true );
         $data[] = $lh;
     }
-    
+
     $back_url = laskuhari_back_url( $data, $redirect_to );
 
     $back_url = apply_filters( "laskuhari_return_url_after_bulk_action", $back_url, $order_ids );

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1811,7 +1811,7 @@ function laskuhari_send_invoice_attached( $order ) {
                 if( ! $sent_to_admin ) {
                     $message = apply_filters(
                         "laskuhari_invoice_email_text_for_other_payment_methods_formatted",
-                        "<p>".nl2br( esc_html( $laskuhari_gateway_object->invoice_email_text_for_other_payment_methods ) )."</p>",
+                        wpautop( wptexturize( $laskuhari_gateway_object->invoice_email_text_for_other_payment_methods ) ),
                         $order
                     );
                     echo $message;

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1055,7 +1055,7 @@ function laskuhari_metabox() {
         return false;
     }
 
-    if( $_GET['action'] == "edit" ) {
+    if( isset( $_GET['action'] ) && $_GET['action'] == "edit" ) {
         add_meta_box(
             'laskuhari_metabox',       // Unique ID
             'Laskuhari',               // Box title
@@ -1299,7 +1299,7 @@ function laskuhari_actions() {
     }
 
     if( isset( $_GET['laskuhari_send_invoice'] ) || ( isset( $_GET['laskuhari'] ) && $_GET['laskuhari'] == "sendonly" ) ) {
-        $order_id = $_GET['order_id'] ? $_GET['order_id'] : $_GET['post'];
+        $order_id = $_GET['order_id'] ?? $_GET['post'];
         $lh = laskuhari_send_invoice( wc_get_order( $order_id ) );
         laskuhari_go_back( $lh );
         exit;
@@ -1307,7 +1307,7 @@ function laskuhari_actions() {
 
     if( isset( $_GET['laskuhari'] ) ) {
         $send       = ($_GET['laskuhari'] == "send");
-        $order_id   = $_GET['order_id'] ? $_GET['order_id'] : $_GET['post'];
+        $order_id   = $_GET['order_id'] ?? $_GET['post'];
         $lh         = laskuhari_process_action( $order_id, $send );
 
         laskuhari_go_back( $lh );

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1205,7 +1205,7 @@ function laskuhari_metabox_html( $post ) {
                 <div id="lahetystapa-lomake2">';
                 $laskuhari->lahetystapa_lomake( $post->ID );
         echo '</div>
-                <input type="button" value="'.$luo_ja_laheta.'" id="laskuhari-create-and-send" onclick="if(!confirm(\''.$luo_laheta_varoitus.'\')) {return false;} laskuhari_admin_action(\'send\');" />         
+                <input type="button" value="'.$luo_ja_laheta.'" id="laskuhari-create-and-send" onclick="if(!confirm(\''.$luo_laheta_varoitus.'\')) {return false;} laskuhari_admin_action(\'send\');" />
             </div>
             <input type="button" id="laskuhari-create-only" value="'.__( $luo_teksti, 'laskuhari' ).'" onclick="if(!confirm(\''.__( $luo_varoitus, 'laskuhari' ).'\')) {return false;} laskuhari_admin_action(\'create\');" />
         </div>';

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -79,12 +79,12 @@ function laskuhari_payment_gateway_load() {
     add_filter( 'bulk_actions-edit-shop_order', 'laskuhari_add_bulk_action_for_invoicing', 20, 1 );
     add_filter( 'handle_bulk_actions-edit-shop_order', 'laskuhari_handle_bulk_actions', 10, 3 );
     add_filter( 'manage_edit-shop_order_columns', 'laskuhari_add_column_to_order_list' );
-	add_filter( 'woocommerce_order_get_payment_method_title', 'laskuhari_add_payment_terms_to_payment_method_title', 10, 2 );
+    add_filter( 'woocommerce_order_get_payment_method_title', 'laskuhari_add_payment_terms_to_payment_method_title', 10, 2 );
 
     if( isset( $_GET['laskuhari_luotu'] ) || isset( $_GET['laskuhari_lahetetty'] ) || isset( $_GET['laskuhari_notice'] ) || isset( $_GET['laskuhari_success'] ) ) {
         add_action( 'admin_notices', 'laskuhari_notices' );
     }
-    
+
 }
 
 require_once plugin_dir_path( __FILE__ ) . 'laskuhari-api.php';
@@ -104,12 +104,12 @@ function laskuhari_json_flag() {
 }
 
 function laskuhari_add_payment_terms_to_payment_method_title( $title, $order ) {
-	if( $payment_terms_name = get_post_meta( $order->get_id(), '_laskuhari_payment_terms_name', true ) ) {
-		if( mb_stripos( $title, $payment_terms_name ) === false ) {
-			$title .= " (" . $payment_terms_name . ")";
-		}
-	}
-	return $title;
+    if( $payment_terms_name = get_post_meta( $order->get_id(), '_laskuhari_payment_terms_name', true ) ) {
+        if( mb_stripos( $title, $payment_terms_name ) === false ) {
+            $title .= " (" . $payment_terms_name . ")";
+        }
+    }
+    return $title;
 }
 
 function lh_create_select_box( $name, $options, $current = '' ) {
@@ -384,7 +384,7 @@ function laskuhari_user_profile_additional_info( $user ) {
             } else {
                 $author_meta_checked = "";
             }
-    
+
             echo '
             <tr>
                 <th>' . $meta_disp_name . '</th>
@@ -551,7 +551,7 @@ function laskuhari_create_product( $product, $update = false ) {
         $product_id   = $product->get_id();
         $variation_id = 0;
     }
-    
+
     $api_url = "https://" . laskuhari_domain() . "/rest-api/tuote/uusi";
 
     $api_url = apply_filters( "laskuhari_create_product_api_url", $api_url, $product );
@@ -736,7 +736,7 @@ function laskuhari_add_webhook( $event, $url ) {
 
 function laskuhari_register_plugin_links( $links, $file ) {
     $base = plugin_basename( __FILE__ );
-    
+
     if( $file == $base ) {
         $links[] = '<a href="https://' . laskuhari_domain() . '/" target="_blank">' . __( 'Kirjaudu Laskuhariin', 'laskuhari' ) . '</a>';
     }
@@ -945,7 +945,7 @@ function get_laskuhari_meta( $order_id, $meta_key, $single = true ) {
 
 function laskuhari_update_order_meta( $order_id )  {
     laskuhari_update_payment_terms_meta( $order_id );
-    
+
     $ytunnus = laskuhari_vat_id_at_checkout();
     if ( isset( $ytunnus ) ) {
         laskuhari_set_order_meta( $order_id, '_laskuhari_ytunnus', $ytunnus, true );
@@ -986,7 +986,7 @@ function laskuhari_metabox() {
     if( ! is_admin() ) {
         return false;
     }
-    
+
     if( $_GET['action'] == "edit" ) {
         add_meta_box(
             'laskuhari_metabox',       // Unique ID
@@ -1013,7 +1013,7 @@ function laskuhari_invoice_status( $order_id ) {
         $lasku_luotu = true;
         $tila        = "LASKU LUOTU";
         $tila_class  = " luotu";
-        
+
         if( $lahetetty ) {
             $tila       = "LASKUTETTU";
             $tila_class = " laskutettu";
@@ -1056,7 +1056,7 @@ function laskuhari_metabox_html( $post ) {
     if( ! is_admin() ) {
         return false;
     }
-    
+
     global $laskuhari_gateway_object;
 
     $tiladata    = laskuhari_invoice_status( $post->ID );
@@ -1107,7 +1107,7 @@ function laskuhari_metabox_html( $post ) {
             }
             $payment_terms_select .= '</select>';
         }
-        
+
         $edit_link           = get_edit_post_link( $post );
         $luo_teksti          = "Luo lasku";
         $luo_varoitus        = 'Haluatko varmasti luoda laskun tästä tilauksesta?';
@@ -1116,7 +1116,7 @@ function laskuhari_metabox_html( $post ) {
 
         $laskuhari = $laskuhari_gateway_object;
         if( $lasku_luotu ) {
-    
+
             $invoice_id = laskuhari_invoice_id_by_order( $order->get_id() );
             if( $invoice_id ) {
                 $open_link = '?avaa=' . $invoice_id;
@@ -1136,7 +1136,7 @@ function laskuhari_metabox_html( $post ) {
             if( $maksuehtonimi ) {
                 echo '<div class="laskuhari-payment-terms-name">'.esc_html( $maksuehtonimi ).'</div>';
             }
-    
+
             echo '
             <div class="laskuhari-laskunumero">' . __( 'Lasku', 'laskuhari' ) . ' ' . $laskunumero.'</div>
             <a class="laskuhari-nappi lataa-lasku" href="' . $edit_link . '&laskuhari_download=current" target="_blank">' . __( 'Lataa PDF', 'laskuhari' ) . '</a>
@@ -1183,11 +1183,11 @@ function laskuhari_add_invoice_surcharge( $cart ) {
     if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
         return;
     }
-    
+
     if( ! isset( WC()->session->chosen_payment_method ) || WC()->session->chosen_payment_method !== "laskuhari" ) {
         return;
     }
-    
+
     $laskutuslisa = $laskuhari->laskutuslisa;
 
     if( $laskutuslisa == 0 ) {
@@ -1204,7 +1204,7 @@ function laskuhari_fallback_notice() {
         <p>Laskuhari for WooCommerce vaatii WooCommerce-lisäosan asennuksen.</p>
     </div>';
 }
-   
+
 function laskuhari_add_gateway( $methods ) {
     $methods[] = 'WC_Gateway_Laskuhari';
     return $methods;
@@ -1236,7 +1236,7 @@ function laskuhari_actions() {
         laskuhari_go_back( $lh );
         exit;
     }
-    
+
     if( isset( $_GET['laskuhari'] ) ) {
         $send       = ($_GET['laskuhari'] == "send");
         $order_id   = $_GET['order_id'] ? $_GET['order_id'] : $_GET['post'];
@@ -1295,7 +1295,7 @@ function laskuhari_back_url( $lh = false, $url = false ) {
     } else {
         $data = $lh;
     }
-    
+
     $remove = array(
         '_wpnonce', 'order_id', 'laskuhari', 'laskuhari_download', 'laskuhari',
         'laskuhari_luotu', 'laskuhari_success', 'laskuhari_lahetetty',
@@ -1521,7 +1521,7 @@ function laskuhari_download( $order_id ) {
             "notice" => urlencode( $error_notice )
         );
     }
-    
+
     $api_url = "https://" . laskuhari_domain() . "/rest-api/lasku/" . $invoice_id . "/pdf-link";
 
     $api_url = apply_filters( "laskuhari_get_pdf_url", $api_url, $order_id );
@@ -1680,7 +1680,7 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
     }
 
     $prices_include_tax = get_post_meta( $order_id, '_prices_include_tax', true ) == 'yes' ? true : false;
-    
+
     // laskunlähetyksen asetukset
     $info = $laskuhari_gateway_object;
     $laskuhari_uid           = $info->uid;
@@ -1819,7 +1819,7 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
 
     $laskettu_summa = 0;
     foreach( $products as $item ) {
-        
+
         $data = $item->get_data();
 
         if( $has_coupons ) {
@@ -1879,7 +1879,7 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
             "yhtveroton"    => $yht_veroton,
             "yhtverollinen" => $yht_verollinen
         ] );
-        
+
         $laskettu_summa += $yht_verollinen;
     }
 
@@ -1928,7 +1928,7 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
 
         $laskettu_summa += ( $cart_discount + $cart_discount_tax ) * -1;
     }
-    
+
     // lisätään maksut
     foreach( $order->get_items('fee') as $item_fee ){
         $fee_name      = $item_fee->get_name();
@@ -2021,7 +2021,7 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
 
     $payload = apply_filters( "laskuhari_create_invoice_payload", $payload, $order_id );
     $payload = json_encode( $payload, laskuhari_json_flag() );
-    
+
     $response = laskuhari_api_request( $payload, $api_url, "Create invoice", "json", false );
 
     $error_notice = "";
@@ -2064,7 +2064,7 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
         update_post_meta( $order->get_id(), '_laskuhari_invoice_number', $laskunro );
         update_post_meta( $order->get_id(), '_laskuhari_invoice_id', $laskuid );
         update_post_meta( $order->get_id(), '_laskuhari_uid', $laskuhari_uid );
-        
+
         $order->add_order_note( __( 'Lasku #' . $laskunro . ' luotu Laskuhariin', 'laskuhari' ) );
 
         if( ! is_laskuhari_allowed_order_status( $order->get_status() ) ) {
@@ -2208,13 +2208,14 @@ function laskuhari_send_invoice( $order, $bulk_action = false ) {
     }
 
     $sent_order = "";
+    $success = "";
 
     if( $can_send ) {
 
         $payload = apply_filters( "laskuhari_send_invoice_payload", $payload, $order_id, $invoice_id );
-    
+
         $payload = json_encode( $payload, laskuhari_json_flag() );
-    
+
         $response = laskuhari_api_request( $payload, $api_url, "Send invoice", "json", false );
 
         if( isset( $response['notice'] ) ) {

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1619,11 +1619,6 @@ function laskuhari_api_request( $payload, $api_url, $action_name = "API request"
     curl_setopt($ch, CURLOPT_POST, TRUE);
     curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
 
-    if( $laskuhari_gateway_object->enforce_ssl != "yes" ) {
-        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, FALSE);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
-    }
-
     $response = curl_exec( $ch );
 
     $curl_errno = curl_errno( $ch );

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -2257,7 +2257,7 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
 
         $order->add_order_note( __( 'Lasku #' . $laskunro . ' luotu Laskuhariin', 'laskuhari' ) );
 
-        if( ! is_laskuhari_allowed_order_status( $order->get_status() ) ) {
+        if( ! is_laskuhari_allowed_order_status( $order->get_status() ) && $order->get_payment_method() === "laskuhari" ) {
             $status_after_creation = apply_filters( "laskuhari_status_after_creation", "processing", $order->get_id() );
             $order->update_status( $status_after_creation );
         }

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -79,6 +79,7 @@ function laskuhari_payment_gateway_load() {
     add_filter( 'bulk_actions-edit-shop_order', 'laskuhari_add_bulk_action_for_invoicing', 20, 1 );
     add_filter( 'handle_bulk_actions-edit-shop_order', 'laskuhari_handle_bulk_actions', 10, 3 );
     add_filter( 'manage_edit-shop_order_columns', 'laskuhari_add_column_to_order_list' );
+	add_filter( 'woocommerce_order_get_payment_method_title', 'laskuhari_add_payment_terms_to_payment_method_title', 10, 2 );
 
     if( isset( $_GET['laskuhari_luotu'] ) || isset( $_GET['laskuhari_lahetetty'] ) || isset( $_GET['laskuhari_notice'] ) || isset( $_GET['laskuhari_success'] ) ) {
         add_action( 'admin_notices', 'laskuhari_notices' );
@@ -100,6 +101,15 @@ function laskuhari_json_flag() {
         return JSON_PARTIAL_OUTPUT_ON_ERROR;
     }
     return JSON_INVALID_UTF8_SUBSTITUTE;
+}
+
+function laskuhari_add_payment_terms_to_payment_method_title( $title, $order ) {
+	if( $payment_terms_name = get_post_meta( $order->get_id(), '_laskuhari_payment_terms_name', true ) ) {
+		if( mb_stripos( $title, $payment_terms_name ) === false ) {
+			$title .= " (" . $payment_terms_name . ")";
+		}
+	}
+	return $title;
 }
 
 function lh_create_select_box( $name, $options, $current = '' ) {

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -2319,6 +2319,8 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
 }
 
 function laskuhari_get_order_send_method( $order_id ) {
+    global $laskuhari_gateway_object;
+
     $send_method = get_post_meta( $order_id, '_laskuhari_laskutustapa', true );
 
     $send_methods = array(
@@ -2328,7 +2330,7 @@ function laskuhari_get_order_send_method( $order_id ) {
     );
 
     if( ! in_array( $send_method, $send_methods ) ) {
-        $send_method = $info->send_method_fallback;
+        $send_method = $laskuhari_gateway_object->send_method_fallback;
     }
 
     return $send_method;

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1619,6 +1619,8 @@ function laskuhari_api_request( $payload, $api_url, $action_name = "API request"
     curl_setopt($ch, CURLOPT_POST, TRUE);
     curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
 
+    $ch = apply_filters( "laskuhari_curl_settings", $ch );
+
     $response = curl_exec( $ch );
 
     $curl_errno = curl_errno( $ch );

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1941,7 +1941,7 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
 
     // calculate shipping cost down to multiple decimals
     // get_shipping_total returns rounded excluding tax
-    $toimitus_veropros  = round( $toimitus_vero / $toimitusmaksu, 2);
+    $toimitus_veropros  = $toimitusmaksu != 0 ? round( $toimitus_vero / $toimitusmaksu, 2) : 0;
     $toimitusmaksu      = round( $toimitusmaksu + $toimitus_vero, 2 ) / ( 1 + $toimitus_veropros );
 
     $cart_discount      = $order->get_discount_total();

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1915,6 +1915,9 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
     $shipping_different = false;
 
     foreach ( $customer as $key => $cdata ) {
+        if( in_array( $key, ["email", "phone"] ) && isset( $shippingdata[$key] ) && $shippingdata[$key] == "" ) {
+            continue;
+        }
         if( isset( $shippingdata[$key] ) && $shippingdata[$key] != $cdata ) {
             $shipping_different = true;
             break;

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -2343,6 +2343,12 @@ function laskuhari_get_order_send_method( $order_id ) {
 function laskuhari_send_invoice( $order, $bulk_action = false ) {
     global $laskuhari_gateway_object;
 
+    if( ! apply_filters( "laskuhari_can_send_invoice", true, $order, $bulk_action ) ) {
+        return array(
+            "notice" => urlencode( __( "Laskun lähetys estetty" ) )
+        );
+    }
+
     // laskunlähetyksen asetukset
     $info = $laskuhari_gateway_object;
     $laskuhari_uid    = $info->uid;

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1355,10 +1355,10 @@ function laskuhari_back_url( $lh = false, $url = false ) {
             "successes" => array()
         );
         foreach( $lh as $datas ) {
-            $data["luotu"][]     = $datas["luotu"];
-            $data["lahetetty"][] = $datas["lahetetty"];
-            $data["notice"][]    = $datas["notice"];
-            $data["success"][]   = $datas["success"];
+            $data["luotu"][]     = $datas["luotu"] ?? "";
+            $data["lahetetty"][] = $datas["lahetetty"] ?? "";
+            $data["notice"][]    = $datas["notice"] ?? "";
+            $data["success"][]   = $datas["success"] ?? "";
         }
     } else {
         $data = $lh;
@@ -1380,10 +1380,10 @@ function laskuhari_back_url( $lh = false, $url = false ) {
     if( is_array( $data ) ) {
         $back = add_query_arg(
             array(
-                'laskuhari_luotu'     => $data["luotu"],
-                'laskuhari_lahetetty' => $data["lahetetty"],
-                'laskuhari_notice'    => $data["notice"],
-                'laskuhari_success'   => $data["success"]
+                'laskuhari_luotu'     => $data["luotu"] ?? "",
+                'laskuhari_lahetetty' => $data["lahetetty"] ?? "",
+                'laskuhari_notice'    => $data["notice"] ?? "",
+                'laskuhari_success'   => $data["success"] ?? ""
             ),
             $back
         );
@@ -1406,11 +1406,15 @@ function laskuhari_not_activated() {
     </div>';
 }
 
+function laskuhari_force_array( $input ) {
+    return is_array( $input ) ? $input : [$input];
+}
+
 function laskuhari_notices() {
-    $notices   = is_array($_GET['laskuhari_notice'])    ? $_GET['laskuhari_notice']    : array($_GET['laskuhari_notice'] ?? "");
-    $successes = is_array($_GET['laskuhari_success'])   ? $_GET['laskuhari_success']   : array($_GET['laskuhari_success'] ?? "");
-    $orders    = is_array($_GET['laskuhari_luotu'])     ? $_GET['laskuhari_luotu']     : array($_GET['laskuhari_luotu'] ?? "");
-    $orders2   = is_array($_GET['laskuhari_lahetetty']) ? $_GET['laskuhari_lahetetty'] : array($_GET['laskuhari_lahetetty'] ?? "");
+    $notices   = laskuhari_force_array( $_GET['laskuhari_notice'] ?? "" );
+    $successes = laskuhari_force_array( $_GET['laskuhari_success'] ?? "" );
+    $orders    = laskuhari_force_array( $_GET['laskuhari_luotu'] ?? "" );
+    $orders2   = laskuhari_force_array( $_GET['laskuhari_lahetetty'] ?? "" );
 
     foreach ( $notices as $key => $notice ) {
         if( $notice != "" ) {

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1388,10 +1388,10 @@ function laskuhari_not_activated() {
 }
 
 function laskuhari_notices() {
-    $notices   = is_array($_GET['laskuhari_notice'])    ? $_GET['laskuhari_notice']    : array($_GET['laskuhari_notice']);
-    $successes = is_array($_GET['laskuhari_success'])   ? $_GET['laskuhari_success']   : array($_GET['laskuhari_success']);
-    $orders    = is_array($_GET['laskuhari_luotu'])     ? $_GET['laskuhari_luotu']     : array($_GET['laskuhari_luotu']);
-    $orders2   = is_array($_GET['laskuhari_lahetetty']) ? $_GET['laskuhari_lahetetty'] : array($_GET['laskuhari_lahetetty']);
+    $notices   = is_array($_GET['laskuhari_notice'])    ? $_GET['laskuhari_notice']    : array($_GET['laskuhari_notice'] ?? "");
+    $successes = is_array($_GET['laskuhari_success'])   ? $_GET['laskuhari_success']   : array($_GET['laskuhari_success'] ?? "");
+    $orders    = is_array($_GET['laskuhari_luotu'])     ? $_GET['laskuhari_luotu']     : array($_GET['laskuhari_luotu'] ?? "");
+    $orders2   = is_array($_GET['laskuhari_lahetetty']) ? $_GET['laskuhari_lahetetty'] : array($_GET['laskuhari_lahetetty'] ?? "");
 
     foreach ( $notices as $key => $notice ) {
         if( $notice != "" ) {
@@ -1662,17 +1662,17 @@ function laskuhari_api_request( $payload, $api_url, $action_name = "API request"
     if( $curl_errno ) {
         return false;
     }
-    
+
     return $response;
 }
 
 function laskuhari_invoice_row( $data ) {
     $row_payload = [
-        "koodi" => $data['product_sku'],
+        "koodi" => $data['product_sku'] ?? "",
         "tyyppi" => "",
         "woocommerce" => [
-            "wc_product_id" => $data['product_id'],
-            "wc_variation_id" => $data['variation_id']
+            "wc_product_id" => $data['product_id'] ?? "",
+            "wc_variation_id" => $data['variation_id'] ?? ""
         ],
         "nimike" => $data['nimike'],
         "maara" => $data['maara'],

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Laskuhari for WooCommerce
 Plugin URI: https://www.laskuhari.fi/woocommerce-laskutus
 Description: Lisää automaattilaskutuksen maksutavaksi WooCommerce-verkkokauppaan sekä mahdollistaa tilausten manuaalisen laskuttamisen
-Version: 1.2
+Version: 1.3
 Author: Datahari Solutions
 Author URI: https://www.datahari.fi
 License: GPLv2
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit; // Exit if accessed directly
 }
 
-$laskuhari_plugin_version = "1.2";
+$laskuhari_plugin_version = "1.3";
 
 $__laskuhari_api_query_count = 0;
 $__laskuhari_api_query_limit = 2;


### PR DESCRIPTION
**Added functionality to send invoices also from other payment methods**
Invoices can now be sent as receipt from other payment gateways. This can be used for example to attach a PDF invoice to the confirmation email of a purchase made by online payment. Invoices made this way are marked as paid.

**Added ability to attach PDF invoice to WooCommerce emails**
PDF invoice can now be attached to the WooCommerce order confirmation email, which is sent when the status of an order changes to "processing". PDF invoice is also always attached to the WC_Email_Customer_Invoice email.

**Added payment terms name in parenthesis after payment method title**
The payment terms of an invoice are now easily visible at the orders list

**Removed ability to disable SSL_VERIFYPEER and SSL_VERIFYHOST in plugin settings**
These settings make the connection insecure and therefore they should not be located in plugin settings. A filter for cURL settings was instead added if someone wants to make this change (or other changes) by code.

**Removed email and phone from shipping/billing address similarity check**
An unnecessary separate shipping address was added to some invoices because the shipping address didn't have an email address or a phone number. Now these fields are not included when checking if the shipping and billing addresses are the same. When these addresses are the same, only billing address is added to invoice.

