### PR TITLE
Released version 1.3.1

### DIFF
--- a/css/staili.css
+++ b/css/staili.css
@@ -49,6 +49,13 @@ a.button.tips.laskuhari-invoice img {
     right: 5px;
 }
 
+.laskuhari-fetch-payment-terms {
+    text-decoration: none;
+    position: relative;
+    top: 1px;
+    left: 4px;
+}
+
 .laskuhari-laskunumero {
     background: #ccc;
     color: #525252;

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1914,11 +1914,19 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
 
     $shipping_different = false;
 
-    foreach ( $customer as $key => $cdata ) {
-        if( in_array( $key, ["email", "phone"] ) && isset( $shippingdata[$key] ) && $shippingdata[$key] == "" ) {
+    foreach ( $customer as $key => $bdata ) {
+        if( ! isset( $shippingdata[$key] ) ) {
             continue;
         }
-        if( isset( $shippingdata[$key] ) && $shippingdata[$key] != $cdata ) {
+
+        $bdata = trim( $bdata );
+        $sdata = trim( $shippingdata[$key] );
+
+        if( in_array( $key, ["email", "phone"] ) && $sdata == "" ) {
+            continue;
+        }
+
+        if( $sdata != "" && $sdata != $bdata ) {
             $shipping_different = true;
             break;
         }
@@ -1991,7 +1999,7 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
         "laskutusosoite" => [
             "yritys" => $customer['company'],
             "ytunnus" => $ytunnus,
-            "henkilo" => $customer['first_name'].' '.$customer['last_name'],
+            "henkilo" => trim( $customer['first_name'].' '.$customer['last_name'] ),
             "lahiosoite" => [
                 $customer['address_1'],
                 $customer['address_2']
@@ -2004,7 +2012,7 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
         ],
         "toimitusosoite" => [
             "yritys" => $shippingdata['company'],
-            "henkilo" => $shippingdata['first_name'].' '.$shippingdata['last_name'],
+            "henkilo" => trim( $shippingdata['first_name'].' '.$shippingdata['last_name'] ),
             "lahiosoite" => [
                 $shippingdata['address_1'],
                 $shippingdata['address_2']

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Laskuhari for WooCommerce
 Plugin URI: https://www.laskuhari.fi/woocommerce-laskutus
 Description: Lisää automaattilaskutuksen maksutavaksi WooCommerce-verkkokauppaan sekä mahdollistaa tilausten manuaalisen laskuttamisen
-Version: 1.3
+Version: 1.3.1
 Author: Datahari Solutions
 Author URI: https://www.datahari.fi
 License: GPLv2
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit; // Exit if accessed directly
 }
 
-$laskuhari_plugin_version = "1.3";
+$laskuhari_plugin_version = "1.3.1";
 
 $__laskuhari_api_query_count = 0;
 $__laskuhari_api_query_limit = 2;


### PR DESCRIPTION
**Added button for updating payment terms list from Laskuhari API**
List of payment terms can now be updated manually after it has been changed in Laskuhari settings. The button is located at the selection of payment terms in the Laskuhari meta box

**Payment terms meta is updated based on API response**
Some complaints indicated that payment terms were not always saved in post meta. This update intends to fix that.

**Fixed empty shipping address being added as separate shipping address**
The space between first and last name was not removed when both fields are empty, resulting in Laskuhari showing there is a separate shipping address on an invoice