### PR TITLE
Released version 1.3.2

### DIFF
--- a/class-wc-gateway-laskuhari.php
+++ b/class-wc-gateway-laskuhari.php
@@ -160,13 +160,7 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
             </select>
             <?php
             if( is_admin() ) {
-                $invoicing_email = get_laskuhari_meta( $order_id, '_laskuhari_email', true );
-                if( ! $invoicing_email ) {
-                    $order = wc_get_order( $order_id );
-                    if( $order ) {
-                        $invoicing_email = $order->get_billing_email();
-                    }
-                }
+                $invoicing_email = laskuhari_get_order_billing_email( $order_id );
                 ?>
                 <div id="laskuhari-sahkoposti-tiedot" style="<?php echo ($laskutustapa == "email" ? '' : 'display: none;'); ?>">
                     <div class="laskuhari-caption"><?php echo __( 'Sähköpostiosoite', 'laskuhari' ); ?>:</div>

--- a/class-wc-gateway-laskuhari.php
+++ b/class-wc-gateway-laskuhari.php
@@ -63,6 +63,8 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
         $this->send_invoice_from_payment_methods            = $this->lh_get_option( 'send_invoice_from_payment_methods', array() );
         $this->invoice_email_text_for_other_payment_methods = trim(rtrim($this->lh_get_option( 'invoice_email_text_for_other_payment_methods' )));
         $this->attach_invoice_to_wc_email                   = $this->lh_get_option( 'attach_invoice_to_wc_email' ) === "yes";
+        $this->paid_stamp                                   = $this->lh_get_option( 'paid_stamp' );
+        $this->receipt_template                             = $this->lh_get_option( 'receipt_template' );
 
         if( ! $only_settings ) {
             add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
@@ -491,6 +493,18 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                 'custom_attributes' => array(
                     'data-placeholder' => __( 'Valitse maksutavat', 'laskuhari' )
                 )
+            ),
+            'paid_stamp' => array(
+                'title'             => __( 'Maksettu-leima', 'laskuhari' ),
+                'label'             => __( 'Lisää maksettu-leima muilla maksutavoilla maksettuihin laskuihin', 'laskuhari' ),
+                'type'              => 'checkbox',
+                'default'           => 'no'
+            ),
+            'receipt_template' => array(
+                'title'             => __( 'Lähetä kuittina', 'laskuhari' ),
+                'label'             => __( 'Käytä kuittipohjaa laskupohjan sijasta muilla maksutavoilla maksetuissa tilauksissa', 'laskuhari' ),
+                'type'              => 'checkbox',
+                'default'           => 'no'
             ),
             'invoice_email_text_for_other_payment_methods' => array(
                 'title'       => __( 'Laskuviesti (muu maksutapa)', 'laskuhari' ),

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -339,6 +339,11 @@ function laskuhari_user_meta() {
             ]
         ),
         array(
+            "name"  => "_laskuhari_billing_email",
+            "title" => __( 'Laskutussähköposti', 'laskuhari' ),
+            "type"  => "text"
+        ),
+        array(
             "name"  => "_laskuhari_ytunnus",
             "title" => __( 'Y-tunnus', 'laskuhari' ),
             "type"  => "text"
@@ -2370,7 +2375,8 @@ function laskuhari_get_order_billing_email( $order ) {
         return "";
     }
 
-    $invoicing_email = get_laskuhari_meta( $order->get_id(), '_laskuhari_email', true );
+    $invoicing_email = get_the_author_meta( "_laskuhari_billing_email", $order->get_customer_id() );
+    $invoicing_email = $invoicing_email ? $invoicing_email : get_laskuhari_meta( $order->get_id(), '_laskuhari_email', true );
     $invoicing_email = $invoicing_email ? $invoicing_email : $order->get_billing_email();
 
     return $invoicing_email;

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -116,7 +116,7 @@ function laskuhari_json_flag() {
 }
 
 function laskuhari_add_payment_terms_to_payment_method_title( $title, $order ) {
-    if( $payment_terms_name = get_post_meta( $order->get_id(), '_laskuhari_payment_terms_name', true ) ) {
+    if( is_admin() && $payment_terms_name = get_post_meta( $order->get_id(), '_laskuhari_payment_terms_name', true ) ) {
         if( mb_stripos( $title, $payment_terms_name ) === false ) {
             $title .= " (" . $payment_terms_name . ")";
         }

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Laskuhari for WooCommerce
 Plugin URI: https://www.laskuhari.fi/woocommerce-laskutus
 Description: Lisää automaattilaskutuksen maksutavaksi WooCommerce-verkkokauppaan sekä mahdollistaa tilausten manuaalisen laskuttamisen
-Version: 1.3.1
+Version: 1.3.2
 Author: Datahari Solutions
 Author URI: https://www.datahari.fi
 License: GPLv2
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit; // Exit if accessed directly
 }
 
-$laskuhari_plugin_version = "1.3.1";
+$laskuhari_plugin_version = "1.3.2";
 
 $__laskuhari_api_query_count = 0;
 $__laskuhari_api_query_limit = 2;


### PR DESCRIPTION
**Added possibility to add a paid stamp to invoices that are sent from other payment methods**
Invoices sent from other payment methods can also be sent with a receipt template instead of an invoice template

**Added separate field for billing email to customer details**
This billing email will only be used for sending an invoice and will override other customer email addresses as default billing email.

**Added support for separate billing email on checkout form**
If a custom billing email field is detected in checkout form, it will be used to send the invoice. Field name must contain one of the following: `laskuhari_billing_email, laskutusemail, laskutussahkoposti, laskutus_email, laskutus_sahkoposti`

**Added possibility to change the filename of the PDF invoice/receipt attached to confirmation email**
Filename can be changed with filters `laskuhari_attachment_template_name` and `laskuhari_attachment_pdf_filename`

**Removed payment terms text from payment method title at checkout**
Payment terms will be shown in parentheses after payment method title in admin area only
