### PR TITLE
Released version 1.4.6

### DIFF
--- a/scripts/create_package.sh
+++ b/scripts/create_package.sh
@@ -25,7 +25,7 @@ rm -rf woocommerce-laskuhari-payment-gateway/README.md
 rm -rf woocommerce-laskuhari-payment-gateway/test
 
 # remove scripts
-rm woocommerce-laskuhari-payment-gateway/scripts
+rm -rf woocommerce-laskuhari-payment-gateway/scripts
 
 # get version number
 VERSION=`grep "Version: " woocommerce-laskuhari-payment-gateway/woocommerce-laskuhari-payment-gateway.php | awk '{print $2}'`

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Laskuhari for WooCommerce
 Plugin URI: https://www.laskuhari.fi/woocommerce-laskutus
 Description: Lisää automaattilaskutuksen maksutavaksi WooCommerce-verkkokauppaan sekä mahdollistaa tilausten manuaalisen laskuttamisen
-Version: 1.4.5
+Version: 1.4.6
 Author: Datahari Solutions
 Author URI: https://www.datahari.fi
 License: GPLv2


### PR DESCRIPTION
**Fixed wrong VAT rate on low price items**
If item price was 0,40 EUR and VAT rate 24 %, it was calculated to be 25 % on the invoice row, since WooCommerce does not save VAT rates on order rows and thus VAT rate needs to be calculated every time. The price and VAT amount are also rounded in WooCommerce. This means VAT of 0,10 EUR will be added to the price without tax of 0,40 EUR and 0,10 EUR is 25% of 0,40 EUR so the VAT rate was calulated wrong. This was fixed by forcing the usage of common Finnish VAT rates on invoice rows.