### PR TITLE
Released version 1.5.1

### DIFF
--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Laskuhari for WooCommerce
 Plugin URI: https://www.laskuhari.fi/woocommerce-laskutus
 Description: Lisää automaattilaskutuksen maksutavaksi WooCommerce-verkkokauppaan sekä mahdollistaa tilausten manuaalisen laskuttamisen
-Version: 1.5
+Version: 1.5.1
 Author: Datahari Solutions
 Author URI: https://www.datahari.fi
 License: GPLv2

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1631,26 +1631,23 @@ function laskuhari_update_payment_status( $order_id, $status_code, $status_name,
     update_post_meta( $order_id, '_laskuhari_payment_status_name', $status_name );
     update_post_meta( $order_id, '_laskuhari_payment_status_id', $status_id );
 
-    if( 1 == $status_code ) {
-        // if invoice status is changed to paid, change order status based on settings
-        $status_after_paid = $laskuhari_gateway_object->lh_get_option( "status_after_paid" );
-        $status_after_paid = apply_filters( "laskuhari_status_after_update_status_paid", $status_after_paid, $order_id );
-        if( $status_after_paid ) {
-            $order = wc_get_order( $order_id );
-            $order->update_status( $status_after_paid );
-        }
-    } elseif( $old_status != "" ) {
-        // if invoice status is changed to unpaid, change order status based on settings
-        // only if order was made by payment gateway
-        $order = wc_get_order( $order_id );
-        if( $order->get_payment_method() === "laskuhari" ) {
-            $status_after_unpaid = $laskuhari_gateway_object->lh_get_option( "status_after_gateway" );
-        } else {
-            $status_after_unpaid = false;
-        }
-        $status_after_unpaid = apply_filters( "laskuhari_status_after_update_status_unpaid", $status_after_unpaid, $order_id );
-        if( $status_after_unpaid ) {
-            $order->update_status( $status_after_unpaid );
+    $order = wc_get_order( $order_id );
+
+    if( $order->get_payment_method() === "laskuhari" ) {
+        if( 1 == $status_code ) {
+            // if invoice status is changed to paid, change order status based on settings
+            $status_after_paid = $laskuhari_gateway_object->lh_get_option( "status_after_paid" );
+            $status_after_paid = apply_filters( "laskuhari_status_after_update_status_paid", $status_after_paid, $order_id );
+            if( $status_after_paid ) {
+                $order->update_status( $status_after_paid );
+            }
+        } elseif( $old_status != "" ) {
+            // if invoice status is changed to unpaid, change order status based on settings
+            // only if order was made by payment gateway
+            $status_after_unpaid = apply_filters( "laskuhari_status_after_update_status_unpaid", $status_after_unpaid, $order_id );
+            if( $status_after_unpaid ) {
+                $order->update_status( $status_after_unpaid );
+            }
         }
     }
 


### PR DESCRIPTION
**Fixed problem with duplicate email confirmations**
When sending a receipt from an order made by other payment methods, a duplicate email confirmation was sent due to the status of the order changing once at order creation and a second time at setting of invoice payment status