### PR TITLE
Released version 1.5.4

### DIFF
--- a/js/public.js
+++ b/js/public.js
@@ -20,11 +20,8 @@ var laskuhari_viime_maksutapa = false;
         }
 
         if( ! laskuhari_updating_checkout ) {
-            $('body').trigger('update_checkout');
             laskuhari_updating_checkout = true;
-            setTimeout( function() {
-                laskuhari_updating_checkout = false;
-            }, 1000 );
+            $('body').trigger('update_checkout');
         }
     }
     function laskuhari_tarkista_laskutustapa(){
@@ -42,6 +39,9 @@ var laskuhari_viime_maksutapa = false;
         });
         $("body").bind("updated_checkout", function(){
             laskuhari_tarkista_laskutustapa();
+            setTimeout(function() {
+                laskuhari_updating_checkout = false;
+            }, 1000);
         });
         $(".woocommerce-checkout").on("checkout_place_order", function() {
             if( $(".laskuhari-place-order-disabled").length ) {

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Laskuhari for WooCommerce
 Plugin URI: https://www.laskuhari.fi/woocommerce-laskutus
 Description: Lisää automaattilaskutuksen maksutavaksi WooCommerce-verkkokauppaan sekä mahdollistaa tilausten manuaalisen laskuttamisen
-Version: 1.5.3
+Version: 1.5.4
 Author: Datahari Solutions
 Author URI: https://www.datahari.fi
 License: GPLv2


### PR DESCRIPTION
**Fixed infinite update_checkout loop on checkout page**
Due to the last update, in some circumstances, the checkout review was being updated constantly in a loop. This has been fixed in this update.