### PR TITLE
Released version 1.5.6

### DIFF
--- a/test/puppeteer/checkout-change-order-status-when-invoicing.test.js
+++ b/test/puppeteer/checkout-change-order-status-when-invoicing.test.js
@@ -34,6 +34,14 @@ test("checkout-change-order-status-when-invoicing", async () => {
         $("#woocommerce_laskuhari_auto_gateway_enabled").prop( "checked", true );
         $("#woocommerce_laskuhari_status_after_gateway").val( "on-hold" );
         $("#woocommerce_laskuhari_status_after_paid").val( "processing" );
+        $("#woocommerce_laskuhari_laskuviesti").val(
+            $("#woocommerce_laskuhari_laskuviesti").val() +
+            " (checkout-change-order-status-when-invoicing)"
+        );
+        $("#woocommerce_laskuhari_instructions").val(
+            $("#woocommerce_laskuhari_instructions").val() +
+            " (checkout-change-order-status-when-invoicing)"
+        );
     } );
 
     // save settings

--- a/test/puppeteer/checkout-change-order-status-when-invoicing.test.js
+++ b/test/puppeteer/checkout-change-order-status-when-invoicing.test.js
@@ -45,11 +45,11 @@ test("checkout-change-order-status-when-invoicing", async () => {
     } );
 
     // save settings
-    await page.click( ".submit .button-primary" );
+    await page.click( ".woocommerce-save-button" );
 
     // wait for settings to be saved
     await page.waitForNavigation();
-    await page.waitFor( ".updated.woocommerce-message" );
+    await page.waitFor( ".updated.inline" );
 
     // log out
     await functions.logout( page );

--- a/test/puppeteer/checkout-create-and-send-as-attachment.test.js
+++ b/test/puppeteer/checkout-create-and-send-as-attachment.test.js
@@ -33,6 +33,14 @@ test("checkout-create-and-send", async () => {
         $("#woocommerce_laskuhari_auto_gateway_create_enabled").prop( "checked", true );
         $("#woocommerce_laskuhari_auto_gateway_enabled").prop( "checked", true );
         $("#woocommerce_laskuhari_attach_invoice_to_wc_email").prop( "checked", true );
+        $("#woocommerce_laskuhari_laskuviesti").val(
+            $("#woocommerce_laskuhari_laskuviesti").val() +
+            " (checkout-create-and-send-as-attachment)"
+        );
+        $("#woocommerce_laskuhari_instructions").val(
+            $("#woocommerce_laskuhari_instructions").val() +
+            " (checkout-create-and-send-as-attachment)"
+        );
     } );
 
     // save settings

--- a/test/puppeteer/checkout-create-and-send-as-attachment.test.js
+++ b/test/puppeteer/checkout-create-and-send-as-attachment.test.js
@@ -1,7 +1,7 @@
 const puppeteer = require('puppeteer');
 const functions = require('./functions.js');
 
-test("checkout-create-and-send", async () => {
+test("checkout-create-and-send-as-attachment", async () => {
     const browser = await puppeteer.launch({
         headless: false,
         defaultViewport: {

--- a/test/puppeteer/checkout-create-and-send-as-attachment.test.js
+++ b/test/puppeteer/checkout-create-and-send-as-attachment.test.js
@@ -44,11 +44,11 @@ test("checkout-create-and-send-as-attachment", async () => {
     } );
 
     // save settings
-    await page.click( ".submit .button-primary" );
+    await page.click( ".woocommerce-save-button" );
 
     // wait for settings to be saved
     await page.waitForNavigation();
-    await page.waitFor( ".updated.woocommerce-message" );
+    await page.waitFor( ".updated.inline" );
 
     // log out
     await functions.logout( page );

--- a/test/puppeteer/checkout-create-and-send.test.js
+++ b/test/puppeteer/checkout-create-and-send.test.js
@@ -32,6 +32,14 @@ test("checkout-create-and-send", async () => {
         let $ = jQuery;
         $("#woocommerce_laskuhari_auto_gateway_create_enabled").prop( "checked", true );
         $("#woocommerce_laskuhari_auto_gateway_enabled").prop( "checked", true );
+        $("#woocommerce_laskuhari_laskuviesti").val(
+            $("#woocommerce_laskuhari_laskuviesti").val() +
+            " (checkout-create-and-send)"
+        );
+        $("#woocommerce_laskuhari_instructions").val(
+            $("#woocommerce_laskuhari_instructions").val() +
+            " (checkout-create-and-send)"
+        );
     } );
 
     // save settings

--- a/test/puppeteer/checkout-create-and-send.test.js
+++ b/test/puppeteer/checkout-create-and-send.test.js
@@ -43,11 +43,11 @@ test("checkout-create-and-send", async () => {
     } );
 
     // save settings
-    await page.click( ".submit .button-primary" );
+    await page.click( ".woocommerce-save-button" );
 
     // wait for settings to be saved
     await page.waitForNavigation();
-    await page.waitFor( ".updated.woocommerce-message" );
+    await page.waitFor( ".updated.inline" );
 
     // log out
     await functions.logout( page );

--- a/test/puppeteer/checkout-create-dont-send.test.js
+++ b/test/puppeteer/checkout-create-dont-send.test.js
@@ -43,11 +43,11 @@ test("checkout-create-dont-send", async () => {
     } );
 
     // save settings
-    await page.click( ".submit .button-primary" );
+    await page.click( ".woocommerce-save-button" );
 
     // wait for settings to be saved
     await page.waitForNavigation();
-    await page.waitFor( ".updated.woocommerce-message" );
+    await page.waitFor( ".updated.inline" );
 
     // log out
     await functions.logout( page );

--- a/test/puppeteer/checkout-create-dont-send.test.js
+++ b/test/puppeteer/checkout-create-dont-send.test.js
@@ -32,6 +32,14 @@ test("checkout-create-dont-send", async () => {
         let $ = jQuery;
         $("#woocommerce_laskuhari_auto_gateway_create_enabled").prop( "checked", true );
         $("#woocommerce_laskuhari_auto_gateway_enabled").prop( "checked", false );
+        $("#woocommerce_laskuhari_laskuviesti").val(
+            $("#woocommerce_laskuhari_laskuviesti").val() +
+            " (checkout-create-dont-send)"
+        );
+        $("#woocommerce_laskuhari_instructions").val(
+            $("#woocommerce_laskuhari_instructions").val() +
+            " (checkout-create-dont-send)"
+        );
     } );
 
     // save settings

--- a/test/puppeteer/checkout-disable-sending-methods.test.js
+++ b/test/puppeteer/checkout-disable-sending-methods.test.js
@@ -34,6 +34,14 @@ test("checkout-disable-sending-methods", async () => {
         $("#woocommerce_laskuhari_email_lasku_kaytossa").prop( "checked", true );
         $("#woocommerce_laskuhari_verkkolasku_kaytossa").prop( "checked", false );
         $("#woocommerce_laskuhari_kirjelasku_kaytossa").prop( "checked", false );
+        $("#woocommerce_laskuhari_laskuviesti").val(
+            $("#woocommerce_laskuhari_laskuviesti").val() +
+            " (checkout-disable-sending-methods)"
+        );
+        $("#woocommerce_laskuhari_instructions").val(
+            $("#woocommerce_laskuhari_instructions").val() +
+            " (checkout-disable-sending-methods)"
+        );
     } );
 
     // save settings

--- a/test/puppeteer/checkout-disable-sending-methods.test.js
+++ b/test/puppeteer/checkout-disable-sending-methods.test.js
@@ -45,11 +45,11 @@ test("checkout-disable-sending-methods", async () => {
     } );
 
     // save settings
-    await page.click( ".submit .button-primary" );
+    await page.click( ".woocommerce-save-button" );
 
     // wait for settings to be saved
     await page.waitForNavigation();
-    await page.waitFor( ".updated.woocommerce-message" );
+    await page.waitFor( ".updated.inline" );
 
     // log out
     await functions.logout( page );
@@ -75,11 +75,11 @@ test("checkout-disable-sending-methods", async () => {
     } );
 
     // save settings
-    await page.click( ".submit .button-primary" );
+    await page.click( ".woocommerce-save-button" );
 
     // wait for settings to be saved
     await page.waitForNavigation();
-    await page.waitFor( ".updated.woocommerce-message" );
+    await page.waitFor( ".updated.inline" );
 
     // log out
     await functions.logout( page );
@@ -105,11 +105,11 @@ test("checkout-disable-sending-methods", async () => {
     } );
 
     // save settings
-    await page.click( ".submit .button-primary" );
+    await page.click( ".woocommerce-save-button" );
 
     // wait for settings to be saved
     await page.waitForNavigation();
-    await page.waitFor( ".updated.woocommerce-message" );
+    await page.waitFor( ".updated.inline" );
 
     // log out
     await functions.logout( page );

--- a/test/puppeteer/checkout-dont-create-dont-send.test.js
+++ b/test/puppeteer/checkout-dont-create-dont-send.test.js
@@ -43,11 +43,11 @@ test("checkout-dont-create-dont-send", async () => {
     } );
 
     // save settings
-    await page.click( ".submit .button-primary" );
+    await page.click( ".woocommerce-save-button" );
 
     // wait for settings to be saved
     await page.waitForNavigation();
-    await page.waitFor( ".updated.woocommerce-message" );
+    await page.waitFor( ".updated.inline" );
 
     // log out
     await functions.logout( page );

--- a/test/puppeteer/checkout-dont-create-dont-send.test.js
+++ b/test/puppeteer/checkout-dont-create-dont-send.test.js
@@ -32,6 +32,14 @@ test("checkout-dont-create-dont-send", async () => {
         let $ = jQuery;
         $("#woocommerce_laskuhari_auto_gateway_create_enabled").prop( "checked", false );
         $("#woocommerce_laskuhari_auto_gateway_enabled").prop( "checked", false );
+        $("#woocommerce_laskuhari_laskuviesti").val(
+            $("#woocommerce_laskuhari_laskuviesti").val() +
+            " (checkout-dont-create-dont-send)"
+        );
+        $("#woocommerce_laskuhari_instructions").val(
+            $("#woocommerce_laskuhari_instructions").val() +
+            " (checkout-dont-create-dont-send)"
+        );
     } );
 
     // save settings

--- a/test/puppeteer/checkout-einvoice.test.js
+++ b/test/puppeteer/checkout-einvoice.test.js
@@ -32,6 +32,14 @@ test("checkout-einvoice", async () => {
         let $ = jQuery;
         $("#woocommerce_laskuhari_auto_gateway_create_enabled").prop( "checked", true );
         $("#woocommerce_laskuhari_auto_gateway_enabled").prop( "checked", true );
+        $("#woocommerce_laskuhari_laskuviesti").val(
+            $("#woocommerce_laskuhari_laskuviesti").val() +
+            " (checkout-einvoice)"
+        );
+        $("#woocommerce_laskuhari_instructions").val(
+            $("#woocommerce_laskuhari_instructions").val() +
+            " (checkout-einvoice)"
+        );
     } );
 
     // save settings

--- a/test/puppeteer/checkout-einvoice.test.js
+++ b/test/puppeteer/checkout-einvoice.test.js
@@ -51,7 +51,7 @@ test("checkout-einvoice", async () => {
     await page.evaluate(function() {
         jQuery("#laskuhari-laskutustapa").val("verkkolasku").change();
     });
-    await page.waitFor( 500 );
+    await page.waitFor( 1000 );
 
     // insert business id
     await page.click( "#laskuhari-ytunnus" );

--- a/test/puppeteer/checkout-einvoice.test.js
+++ b/test/puppeteer/checkout-einvoice.test.js
@@ -43,11 +43,11 @@ test("checkout-einvoice", async () => {
     } );
 
     // save settings
-    await page.click( ".submit .button-primary" );
+    await page.click( ".woocommerce-save-button" );
 
     // wait for settings to be saved
     await page.waitForNavigation();
-    await page.waitFor( ".updated.woocommerce-message" );
+    await page.waitFor( ".updated.inline" );
 
     // log out
     await functions.logout( page );

--- a/test/puppeteer/checkout-letter.test.js
+++ b/test/puppeteer/checkout-letter.test.js
@@ -51,7 +51,7 @@ test("checkout-letter", async () => {
     await page.evaluate(function() {
         jQuery("#laskuhari-laskutustapa").val("kirje").change();
     });
-    await page.waitFor( 500 );
+    await page.waitFor( 1000 );
 
     // insert reference
     await page.click( "#laskuhari-viitteenne" );

--- a/test/puppeteer/checkout-letter.test.js
+++ b/test/puppeteer/checkout-letter.test.js
@@ -32,6 +32,14 @@ test("checkout-letter", async () => {
         let $ = jQuery;
         $("#woocommerce_laskuhari_auto_gateway_create_enabled").prop( "checked", true );
         $("#woocommerce_laskuhari_auto_gateway_enabled").prop( "checked", true );
+        $("#woocommerce_laskuhari_laskuviesti").val(
+            $("#woocommerce_laskuhari_laskuviesti").val() +
+            " (checkout-letter)"
+        );
+        $("#woocommerce_laskuhari_instructions").val(
+            $("#woocommerce_laskuhari_instructions").val() +
+            " (checkout-letter)"
+        );
     } );
 
     // save settings

--- a/test/puppeteer/checkout-letter.test.js
+++ b/test/puppeteer/checkout-letter.test.js
@@ -43,11 +43,11 @@ test("checkout-letter", async () => {
     } );
 
     // save settings
-    await page.click( ".submit .button-primary" );
+    await page.click( ".woocommerce-save-button" );
 
     // wait for settings to be saved
     await page.waitForNavigation();
-    await page.waitFor( ".updated.woocommerce-message" );
+    await page.waitFor( ".updated.inline" );
 
     // log out
     await functions.logout( page );

--- a/test/puppeteer/checkout-with-invoicing-fee.test.js
+++ b/test/puppeteer/checkout-with-invoicing-fee.test.js
@@ -45,11 +45,11 @@ test("checkout-with-invoicing-fee", async () => {
     } );
 
     // save settings
-    await page.click( ".submit .button-primary" );
+    await page.click( ".woocommerce-save-button" );
 
     // wait for settings to be saved
     await page.waitForNavigation();
-    await page.waitFor( ".updated.woocommerce-message" );
+    await page.waitFor( ".updated.inline" );
 
     // log out
     await functions.logout( page );

--- a/test/puppeteer/checkout-with-invoicing-fee.test.js
+++ b/test/puppeteer/checkout-with-invoicing-fee.test.js
@@ -34,6 +34,14 @@ test("checkout-with-invoicing-fee", async () => {
         $("#woocommerce_laskuhari_auto_gateway_enabled").prop( "checked", false );
         $("#woocommerce_laskuhari_laskutuslisa").val("1,65");
         $("#woocommerce_laskuhari_laskutuslisa_alv").val("24");
+        $("#woocommerce_laskuhari_laskuviesti").val(
+            $("#woocommerce_laskuhari_laskuviesti").val() +
+            " (checkout-with-invoicing-fee)"
+        );
+        $("#woocommerce_laskuhari_instructions").val(
+            $("#woocommerce_laskuhari_instructions").val() +
+            " (checkout-with-invoicing-fee)"
+        );
     } );
 
     // save settings

--- a/test/puppeteer/functions.js
+++ b/test/puppeteer/functions.js
@@ -90,7 +90,7 @@ exports.make_order = async function( page ) {
     await page.evaluate(function() {
         jQuery("#laskuhari-laskutustapa").val("email").change();
     });
-    await page.waitFor( 500 );
+    await page.waitFor( 1000 );
 
     // insert reference
     await page.click( "#laskuhari-viitteenne" );

--- a/test/puppeteer/manual-order.test.js
+++ b/test/puppeteer/manual-order.test.js
@@ -38,7 +38,7 @@ test("manual-order", async () => {
     await functions.reset_settings( page );
 
     // save settings
-    await page.click( ".submit .button-primary" );
+    await page.click( ".woocommerce-save-button" );
 
     // go to new order creation
     await page.goto( config.wordpress_url + "/wp-admin/post-new.php?post_type=shop_order" );

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1016,10 +1016,39 @@ function laskuhari_einvoice_notices( $fields, $errors ) {
         if ( ! $_POST['laskuhari-laskutustapa'] ) {
             $errors->add( 'validation', __( 'Ole hyvä ja valitse laskutustapa' ) );
         }
-        if ( mb_strlen( laskuhari_vat_id_at_checkout() ) < 6 && $_POST['laskuhari-laskutustapa'] == "verkkolasku" ) {
-            $errors->add( 'validation', __( 'Ole hyvä ja syötä y-tunnus verkkolaskun lähetystä varten' ) );
+        if ( ! laskuhari_is_valid_vat_id( laskuhari_vat_id_at_checkout() ) && in_array( $_POST['laskuhari-laskutustapa'], laskuhari_vat_id_mandatory_for_methods() ) ) {
+            $errors->add( 'validation', __( 'Y-tunnus on pakollinen '.laskuhari_method_name_by_slug( $_POST['laskuhari-laskutustapa'] ).'-laskutustavalla' ) );
         }
     }
+}
+
+// Check if a VAT ID is valid
+
+function laskuhari_is_valid_vat_id( $vat_id ) {
+    $is_valid = mb_strlen( laskuhari_vat_id_at_checkout() ) >= 6;
+    return apply_filters( "laskuhari_is_valid_vat_id", $is_valid, $vat_id );
+}
+
+// Set which invoicing methods require VAT ID
+
+function laskuhari_vat_id_mandatory_for_methods() {
+    return apply_filters( "laskuhari_vat_id_mandatory_for_methods", [
+        "verkkolasku",
+        //"kirje",
+        //"email",
+    ] );
+}
+
+// Return name of invoicing method by slug
+
+function laskuhari_method_name_by_slug( $slug ) {
+    $names = apply_filters( "laskuhari_method_names_by_slug", [
+        "verkkolasku" => "verkkolasku",
+        "kirje" => "kirje",
+        "email" => "sähköposti",
+    ] );
+
+    return $names[$slug];
 }
 
 // Päivitä Laskuharista tuleva metadata

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -24,6 +24,8 @@ $__laskuhari_api_query_limit = 2;
 
 require_once plugin_dir_path( __FILE__ ) . 'updater.php';
 
+laskuhari_maybe_add_vat_id_field();
+
 add_action( 'woocommerce_init', function() {
     global $laskuhari_gateway_object;
 
@@ -1049,6 +1051,28 @@ function laskuhari_method_name_by_slug( $slug ) {
     ] );
 
     return $names[$slug];
+}
+
+// add a separate vat id field to billing details if vat id
+// is required for other invoicing methods than eInvoice
+
+function laskuhari_maybe_add_vat_id_field() {
+    add_filter( 'woocommerce_billing_fields', function( $fields ) {
+        $mandatory_for_methods = laskuhari_vat_id_mandatory_for_methods();
+
+        foreach( $mandatory_for_methods as $method ) {
+            if( $method !== "verkkolasku" ) {
+                $fields['billing_ytunnus'] = [
+                    'label' => __('Y-tunnus', 'woocommerce'),
+                    'required' => false,
+                    'type' => 'text',
+                ];
+                break;
+            }
+        }
+
+        return $fields;
+    });
 }
 
 // Päivitä Laskuharista tuleva metadata

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -24,8 +24,6 @@ $__laskuhari_api_query_limit = 2;
 
 require_once plugin_dir_path( __FILE__ ) . 'updater.php';
 
-laskuhari_maybe_add_vat_id_field();
-
 add_action( 'woocommerce_init', function() {
     global $laskuhari_gateway_object;
 
@@ -56,6 +54,10 @@ function laskuhari_payment_gateway_load() {
         return;
     } elseif ( $laskuhari_gateway_object->demotila ) {
         add_action( 'admin_notices', 'laskuhari_demo_notice' );
+    }
+
+    if( $laskuhari_gateway_object->lh_get_option( 'gateway_enabled' ) === 'yes' ) {
+        laskuhari_maybe_add_vat_id_field();
     }
 
     laskuhari_actions();

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1062,14 +1062,35 @@ function laskuhari_maybe_add_vat_id_field() {
     add_filter( 'woocommerce_billing_fields', function( $fields ) {
         $mandatory_for_methods = laskuhari_vat_id_mandatory_for_methods();
 
+        // insert vat id field after field with this key
+        $insert_after = apply_filters( "laskuhari_insert_vat_id_after_field", "billing_company", $fields );
+
+        // vat id field details
+        $billing_field = apply_filters( "laskuhari_vat_id_field", [
+            'label' => __('Y-tunnus', 'laskuhari'),
+            'required' => false,
+            'type' => 'text',
+        ] );
+
         foreach( $mandatory_for_methods as $method ) {
+            // if a method other than eInvoice is found
             if( $method !== "verkkolasku" ) {
-                $fields['billing_ytunnus'] = [
-                    'label' => __('Y-tunnus', 'woocommerce'),
-                    'required' => false,
-                    'type' => 'text',
-                ];
-                break;
+                $new_fields = [];
+
+                // insert vat id field after specified field
+                foreach( $fields as $name => $data ) {
+                    $new_fields[$name] = $data;
+                    if( $name === $insert_after ) {
+                        $new_fields['billing_ytunnus'] = $billing_field;
+                    }
+                }
+
+                // if specified field was not found, add field to the end
+                if( ! isset( $fields['billing_ytunnus'] ) ) {
+                    $new_fields['billing_ytunnus'] = $billing_field;
+                }
+
+                return $new_fields;
             }
         }
 

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -58,6 +58,12 @@ function laskuhari_payment_gateway_load() {
 
     if( $laskuhari_gateway_object->lh_get_option( 'gateway_enabled' ) === 'yes' ) {
         laskuhari_maybe_add_vat_id_field();
+        add_action( 'woocommerce_checkout_update_order_meta', 'laskuhari_checkout_update_order_meta' );
+        add_action( 'woocommerce_after_checkout_validation', 'laskuhari_einvoice_notices', 10, 2);
+        add_action( 'wp_footer', 'laskuhari_add_public_scripts' );
+        add_action( 'wp_footer', 'laskuhari_add_styles' );
+        add_action( 'woocommerce_cart_calculate_fees','laskuhari_add_invoice_surcharge', 10, 1 );
+        add_action( 'woocommerce_checkout_update_order_review','laskuhari_checkout_update_order_review', 10, 1 );
     }
 
     laskuhari_actions();
@@ -69,20 +75,14 @@ function laskuhari_payment_gateway_load() {
         add_action( 'woocommerce_update_product_variation', 'laskuhari_sync_product_on_save', 10, 1 );
     }
 
-    add_action( 'wp_footer', 'laskuhari_add_public_scripts' );
-    add_action( 'wp_footer', 'laskuhari_add_styles' );
     add_action( 'admin_print_scripts', 'laskuhari_add_public_scripts' );
     add_action( 'admin_print_scripts', 'laskuhari_add_admin_scripts' );
     add_action( 'admin_print_styles', 'laskuhari_add_styles' );
-    add_action( 'woocommerce_cart_calculate_fees','laskuhari_add_invoice_surcharge', 10, 1 );
-    add_action( 'woocommerce_checkout_update_order_review','laskuhari_checkout_update_order_review', 10, 1 );
     add_action( 'show_user_profile', 'laskuhari_user_profile_additional_info' );
     add_action( 'edit_user_profile', 'laskuhari_user_profile_additional_info' );
     add_action( 'personal_options_update', 'laskuhari_update_user_meta' );
     add_action( 'edit_user_profile_update', 'laskuhari_update_user_meta' );
     add_action( 'manage_shop_order_posts_custom_column', 'laskuhari_add_invoice_status_to_custom_order_list_column' );
-    add_action( 'woocommerce_after_checkout_validation', 'laskuhari_einvoice_notices', 10, 2);
-    add_action( 'woocommerce_checkout_update_order_meta', 'laskuhari_checkout_update_order_meta' );
     add_action( 'add_meta_boxes', 'laskuhari_metabox' );
 
     add_action( 'woocommerce_order_status_cancelled_to_processing_notification', "laskuhari_maybe_send_invoice_attached", 10, 1 );

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Laskuhari for WooCommerce
 Plugin URI: https://www.laskuhari.fi/woocommerce-laskutus
 Description: Lisää automaattilaskutuksen maksutavaksi WooCommerce-verkkokauppaan sekä mahdollistaa tilausten manuaalisen laskuttamisen
-Version: 1.5.5
+Version: 1.5.6
 Author: Datahari Solutions
 Author URI: https://www.datahari.fi
 License: GPLv2


### PR DESCRIPTION
**Added hook for requiring VAT ID in checkout form for other invoicing methods**
With filter `laskuhari_vat_id_mandatory_for_methods` you can now set other methods than eInvoice to have it required to fill in a VAT ID before continuing with checkout. A separate VAT ID field will be added to the checkout form when other invoicing methods than eInvoice have the field required. The VAT ID field will be added below business name in the checkout form, and the position can be changed via filter `laskuhari_insert_vat_id_after_field`

**Removed unused scripts when Laskuhari payment method is not enabled**
Some actions and scripts used for the Laskuhari payment method were added to the frontend even though the method was disabled. Now the extra actions and scripts have been removed.

**Tested with WordPress 6.1.1**
Tested functionality with WordPress 6.1.1 and fixed end-to-end tests to work with new version (some button selectors had changed)