### PR TITLE
Released version 1.5.7

### DIFF
--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1060,6 +1060,10 @@ function laskuhari_method_name_by_slug( $slug ) {
 
 function laskuhari_maybe_add_vat_id_field() {
     add_filter( 'woocommerce_billing_fields', function( $fields ) {
+        if( laskuhari_vat_id_custom_field_exists( ["billing" => $fields] ) ) {
+            return $fields;
+        }
+
         $mandatory_for_methods = laskuhari_vat_id_mandatory_for_methods();
 
         // insert vat id field after field with this key
@@ -1177,8 +1181,10 @@ function laskuhari_update_order_meta( $order_id )  {
     }
 }
 
-function laskuhari_vat_id_custom_field_exists() {
-    $field_data = WC()->checkout->get_checkout_fields();
+function laskuhari_vat_id_custom_field_exists( $field_data = null ) {
+    if( null === $field_data ) {
+        $field_data = WC()->checkout->get_checkout_fields();
+    }
     foreach( $field_data as $type => $fields ) {
         foreach( $fields as $field_name => $field_settings ) {
             if( lh_is_vat_id_field( $field_name ) ) {

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1090,7 +1090,7 @@ function laskuhari_maybe_add_vat_id_field() {
                 }
 
                 // if specified field was not found, add field to the end
-                if( ! isset( $fields['billing_ytunnus'] ) ) {
+                if( ! isset( $new_fields['billing_ytunnus'] ) ) {
                     $new_fields['billing_ytunnus'] = $billing_field;
                 }
 

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1059,6 +1059,8 @@ function laskuhari_method_name_by_slug( $slug ) {
 // is required for other invoicing methods than eInvoice
 
 function laskuhari_maybe_add_vat_id_field() {
+    $priority = apply_filters( "laskuhari_woocommerce_billing_fields_filter_priority", 1100 );
+
     add_filter( 'woocommerce_billing_fields', function( $fields ) {
         if( laskuhari_vat_id_custom_field_exists( ["billing" => $fields] ) ) {
             return $fields;
@@ -1099,7 +1101,7 @@ function laskuhari_maybe_add_vat_id_field() {
         }
 
         return $fields;
-    });
+    }, $priority );
 }
 
 // Päivitä Laskuharista tuleva metadata

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Laskuhari for WooCommerce
 Plugin URI: https://www.laskuhari.fi/woocommerce-laskutus
 Description: Lisää automaattilaskutuksen maksutavaksi WooCommerce-verkkokauppaan sekä mahdollistaa tilausten manuaalisen laskuttamisen
-Version: 1.5.6
+Version: 1.5.7
 Author: Datahari Solutions
 Author URI: https://www.datahari.fi
 License: GPLv2


### PR DESCRIPTION
**Fixed compatibility with Checkout Field Editor plugin**
Checkout Field Editor plugin overrode addition of VAT ID field to checkout fields. Increased the priority of `woocommerce_billing_fields` filter to 1100 and added a filter `laskuhari_woocommerce_billing_fields_filter_priority` to change that priority.

**Fixed duplicate VAT ID field at checkout**
If the user had already added a custom VAT ID field at checkout via a plugin or code snippet, the Laskuhari plugin added another one. This has been fixed now.

**Fixed fallback of adding VAT ID field to the end of checkout fields**
If the VAT ID field was set to be inserted after an unknown checkout field, it was supposed to be added to the end of the checkout fields, but this didn't work because of a typo