### PR TITLE
Released version 1.6.1

### DIFF
--- a/class-wc-gateway-laskuhari.php
+++ b/class-wc-gateway-laskuhari.php
@@ -437,7 +437,7 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                 'title'       => __( 'Lähetystapa (fallback)', 'laskuhari' ),
                 'label'       => __( 'Valitse laskujen lähetystapa', 'laskuhari' ),
                 'type'        => 'select',
-                'description' => __( 'Valitse tapa, jolla haluat lähettää massatoiminnolla lähetettävät laskut ja laskut, joiden lähetystapaa ei ole valittu', 'laskuhari' ),
+                'description' => __( 'Valitse tapa, jolla haluat lähettää laskut, joiden lähetystapaa ei ole valittu', 'laskuhari' ),
                 'default'     => $this->lh_get_option( 'lahetystapa_manuaalinen', 'ei' ),
                 'options'     => array(
                     'email' => __( 'Sähköpostilasku', 'laskuhari' ),

--- a/js/admin.js
+++ b/js/admin.js
@@ -36,6 +36,14 @@
 		$("body").on( "click", ".laskuhari-sidebutton-menu a", function() {
 			$("#"+$(this).closest(".laskuhari-sidebutton-menu").attr("id")).slideUp();
 		} );
+		$("body").on( "submit", "#posts-filter", function() {
+			if( $("#bulk-action-selector-top").val() === "laskuhari_batch_send" && ! confirm( "Haluatko varmasti luoda ja LÄHETTÄÄ laskut valituista tilauksista?" ) ) {
+				return false;
+			}
+			if( $("#bulk-action-selector-top").val() === "laskuhari_batch_create" && ! confirm( "Haluatko varmasti luoda laskut valituista tilauksista? (laskuja ei lähetetä)" ) ) {
+				return false;
+			}
+		} );
 	});
 })(jQuery);
 

--- a/test/puppeteer/functions.js
+++ b/test/puppeteer/functions.js
@@ -1,5 +1,9 @@
 const config = require( "./config.js" );
 
+const accept_dialog = dialog => {
+    dialog.accept("1.43");
+};
+
 exports.login = async function( page ) {
     await page.waitFor( "#user_login" );
     await page.click( "#user_login" );
@@ -158,4 +162,87 @@ exports.reset_settings = async function( page ) {
         $("#woocommerce_laskuhari_status_after_gateway").val("processing");
         $("#woocommerce_laskuhari_status_after_paid").val("");
     } );
+}
+
+exports.create_manual_order = async function( page ) {
+    // go to new order creation
+    await page.goto( config.wordpress_url + "/wp-admin/post-new.php?post_type=shop_order" );
+
+    // click billing address edit button
+    await page.waitFor( ".order_data_column a.edit_address" );
+    await page.click( ".order_data_column a.edit_address" );
+
+    // input customer details
+    await page.waitFor( "#_billing_first_name" );
+    await page.click( "#_billing_first_name" );
+    await page.keyboard.type( "Jack" );
+    await page.click( "#_billing_last_name" );
+    await page.keyboard.type( "Smith" );
+    await page.click( "#_billing_address_1" );
+    await page.keyboard.type( "Jack's road" );
+    await page.click( "#_billing_city" );
+    await page.keyboard.type( "Jackcity" );
+    await page.click( "#_billing_postcode" );
+    await page.keyboard.type( "54321" );
+    await page.click( "#_billing_email" );
+    await page.keyboard.type( config.test_email );
+
+    // click "Add line item"
+    await page.click( ".button.add-line-item" );
+    await page.waitFor( 600 );
+
+    // click "Add product"
+    await page.click( ".button.add-order-item" );
+    await page.waitFor( 400 );
+
+    // click "Search for a product"
+    await page.hover( ".wc-backbone-modal-content .select2-selection--single" );
+    await page.waitFor( 200 );
+    await page.click( ".wc-backbone-modal-content .select2-selection--single" );
+    await page.waitFor( 700 );
+
+    // input search keyword
+    await page.click( ".select2-container .select2-search__field[aria-expanded=true]" );
+    await page.keyboard.type( "Hoodie" );
+
+    // wait for results
+    await page.waitFor( ".select2-results__option[role=option]:not(.loading-results)" );
+
+    // click on first result
+    await page.click( ".select2-results__option[role=option]:not(.loading-results)" );
+
+    // click on add product
+    await page.click( ".wc-backbone-modal-content .button.button-primary.button-large" );
+
+    // wait for product to appear in list
+    await page.waitFor( "#order_line_items tr.item" );
+    await page.waitFor( 1000 );
+
+    // click "Add line item"
+    await page.click( ".button.add-line-item" );
+    await page.waitFor( 600 );
+
+    // prepare for the fee amount prompt
+    page.off('dialog', accept_dialog);
+    page.on('dialog', accept_dialog);
+
+    // click "Add fee"
+    await page.click( ".button.add-order-fee" );
+    await page.waitFor( 2000 );
+
+    await page.waitForSelector( ".button.button-primary.calculate-action", {
+        visible: true
+    } );
+
+    // click on "calculate"
+    await page.click( ".button.button-primary.calculate-action" );
+
+    // wait for changes to take effect
+    await page.waitFor( 3000 );
+
+    // create order
+    await page.click( ".button.save_order.button-primary" );
+
+    // wait for page to load
+    await page.waitFor( "#laskuhari_metabox" );
 }

--- a/test/puppeteer/functions.js
+++ b/test/puppeteer/functions.js
@@ -74,6 +74,8 @@ exports.make_order_before_select_invoice_method = async function( page ) {
 }
 
 exports.place_order = async function( page ) {
+    await page.waitFor(2000);
+
     // send order
     await page.click( "#place_order" );
 

--- a/test/puppeteer/functions.js
+++ b/test/puppeteer/functions.js
@@ -246,3 +246,15 @@ exports.create_manual_order = async function( page ) {
     // wait for page to load
     await page.waitFor( "#laskuhari_metabox" );
 }
+
+exports.set_field_value = async function( page, selector, text ) {
+    let element = await page.waitForSelector( selector, {
+        visible: true
+    } );
+    let type = await element.evaluate( el => el.type );
+    if( ["select-one"].includes( type ) ) {
+        await element.select( text );
+    } else {
+        await element.type( text );
+    }
+}

--- a/test/puppeteer/manual-order.test.js
+++ b/test/puppeteer/manual-order.test.js
@@ -40,81 +40,8 @@ test("manual-order", async () => {
     // save settings
     await page.click( ".woocommerce-save-button" );
 
-    // go to new order creation
-    await page.goto( config.wordpress_url + "/wp-admin/post-new.php?post_type=shop_order" );
-
-    // click billing address edit button
-    await page.waitFor( ".order_data_column a.edit_address" );
-    await page.click( ".order_data_column a.edit_address" );
-
-    // input customer details
-    await page.waitFor( "#_billing_first_name" );
-    await page.click( "#_billing_first_name" );
-    await page.keyboard.type( "Jack" );
-    await page.click( "#_billing_last_name" );
-    await page.keyboard.type( "Smith" );
-    await page.click( "#_billing_address_1" );
-    await page.keyboard.type( "Jack's road" );
-    await page.click( "#_billing_city" );
-    await page.keyboard.type( "Jackcity" );
-    await page.click( "#_billing_postcode" );
-    await page.keyboard.type( "54321" );
-
-    // click "Add line item"
-    await page.click( ".button.add-line-item" );
-    await page.waitFor( 600 );
-
-    // click "Add product"
-    await page.click( ".button.add-order-item" );
-    await page.waitFor( 400 );
-
-    // click "Search for a product"
-    await page.hover( ".wc-backbone-modal-content .select2-selection--single" );
-    await page.waitFor( 200 );
-    await page.click( ".wc-backbone-modal-content .select2-selection--single" );
-    await page.waitFor( 700 );
-
-    // input search keyword
-    await page.click( ".select2-container .select2-search__field[aria-expanded=true]" );
-    await page.keyboard.type( "Hoodie" );
-
-    // wait for results
-    await page.waitFor( ".select2-results__option[role=option]:not(.loading-results)" );
-
-    // click on first result
-    await page.click( ".select2-results__option[role=option]:not(.loading-results)" );
-
-    // click on add product
-    await page.click( ".wc-backbone-modal-content .button.button-primary.button-large" );
-
-    // wait for product to appear in list
-    await page.waitFor( "#order_line_items tr.item" );
-    await page.waitFor( 1000 );
-
-    // click "Add line item"
-    await page.click( ".button.add-line-item" );
-    await page.waitFor( 600 );
-
-    // prepare for the fee amount prompt
-    page.on('dialog', dialog => {
-        dialog.accept("1.43");
-    });
-
-    // click "Add fee"
-    await page.click( ".button.add-order-fee" );
-    await page.waitFor( 2000 );
-
-    // click on "calculate"
-    await page.click( ".button.button-primary.calculate-action" );
-
-    // wait for changes to take effect
-    await page.waitFor( 3000 );
-
-    // create order
-    await page.click( ".button.save_order.button-primary" );
-
-    // wait for page to load
-    await page.waitFor( "#laskuhari_metabox" );
+    // create manual order
+    await functions.create_manual_order( page );
 
     // check that invoice was not created
     let element = await page.$('.laskuhari-tila');

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -1696,21 +1696,21 @@ function laskuhari_notices() {
 
     foreach ( $successes as $key => $notice ) {
         if( $notice != "" ) {
-            echo '<div class="notice notice-success is-dismissible"><p>' . esc_html( $notice ) . '</p></div>';
+            echo '<div class="notice notice-success is-dismissible" data-testid="laskuhari-success"><p>' . esc_html( $notice ) . '</p></div>';
         }
     }
 
     foreach ( $orders as $key => $notice ) {
         if( $notice != "" ) {
             $order = wc_get_order( $notice );
-            echo '<div class="notice notice-success is-dismissible"><p>Tilauksesta #' . esc_html( $order->get_order_number() ) . ' luotu lasku</p></div>';
+            echo '<div class="notice notice-success is-dismissible" data-testid="invoice-created" data-order-id="'.$order->get_id().'"><p>Tilauksesta #' . esc_html( $order->get_order_number() ) . ' luotu lasku</p></div>';
         }
     }
 
     foreach ( $orders2 as $key => $notice ) {
         if( $notice != "" ) {
             $order = wc_get_order( $notice );
-            echo '<div class="notice notice-success is-dismissible"><p>Tilauksesta #' . esc_html( $order->get_order_number() ) . ' lähetetty lasku</p></div>';
+            echo '<div class="notice notice-success is-dismissible" data-testid="invoice-sent" data-order-id="'.$order->get_id().'"><p>Tilauksesta #' . esc_html( $order->get_order_number() ) . ' lähetetty lasku</p></div>';
         }
     }
 }

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -946,7 +946,8 @@ function laskuhari_add_invoice_status_to_custom_order_list_column( $column ) {
 }
 
 function laskuhari_add_bulk_action_for_invoicing( $actions ) {
-    $actions['laskuhari-batch-send'] = __( 'Laskuta valitut tilaukset (Laskuhari)', 'laskuhari' );
+    $actions['laskuhari_batch_send'] = __( 'Luo ja lähetä laskut valituista tilauksista (Laskuhari)', 'laskuhari' );
+    $actions['laskuhari_batch_create'] = __( 'Luo laskut valituista tilauksista (älä lähetä) (Laskuhari)', 'laskuhari' );
     return $actions;
 }
 
@@ -963,11 +964,16 @@ function laskuhari_handle_bulk_actions( $redirect_to, $action, $order_ids ) {
         return false;
     }
 
-    if ( $action !== 'laskuhari-batch-send' ) {
+    $allowed_actions = [
+        "laskuhari_batch_send",
+        "laskuhari_batch_create",
+    ];
+
+    if ( ! in_array( $action, $allowed_actions ) ) {
         return $redirect_to;
     }
 
-    $send = apply_filters( "laskuhari_bulk_action_send", true, $order_ids );
+    $send = $action === "laskuhari_batch_send";
 
     $data = array();
 
@@ -989,6 +995,7 @@ function laskuhari_handle_bulk_actions( $redirect_to, $action, $order_ids ) {
     }
 
     foreach( $_GET['post'] as $order_id ) {
+        $send   = apply_filters( "laskuhari_bulk_action_send", $send, $order_id );
         $lh     = laskuhari_process_action( $order_id, $send, true );
         $data[] = $lh;
     }

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Laskuhari for WooCommerce
 Plugin URI: https://www.laskuhari.fi/woocommerce-laskutus
 Description: Lisää automaattilaskutuksen maksutavaksi WooCommerce-verkkokauppaan sekä mahdollistaa tilausten manuaalisen laskuttamisen
-Version: 1.6
+Version: 1.6.1
 Author: Datahari Solutions
 Author URI: https://www.datahari.fi
 License: GPLv2


### PR DESCRIPTION
**Added separate send invoices / create invoices actions to bulk actions**
From the bulk action menu, you can now select separately an action to create invoices of selected orders (without sending) and create + send invoices of selected orders.

Previously the bulk action had unexpected behavior when the invoice sending method fallback option was set to "create, don't send". If an invoicing method already was selected on the order, the created invoice was sent anyway, even though the fallback option to not send was enabled. The description for the fallback method implied that no bulk sending would happen if it was selected as "create, don't send" but this was not the case. Now there is a separate option in the bulk action menu for sending / creating & sending so that there will be no question of the behavior.

**Added end-to-end tests for bulk action**
End-to-end tests were added for bulk action logic, so that in the future it will work as expected