### PR TITLE
Released version 1.7.2

### DIFF
--- a/src/WC_Gateway_Laskuhari.php
+++ b/src/WC_Gateway_Laskuhari.php
@@ -15,6 +15,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
 
     /**
+     * A static instance of this class
+     */
+    protected static $instance;
+
+    /**
      * Invoicing fee amount
      *
      * @var float
@@ -213,6 +218,26 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
     public $receipt_template;
 
     /**
+     * Whether actions are already added
+     *
+     * @var bool
+     */
+    protected static $actions_added = false;
+
+    /**
+     * Get a static instance of this class
+     *
+     * @return WC_Gateway_Laskuhari
+     */
+    public static function get_instance() {
+        if ( ! isset( self::$instance ) ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
      * Construct the gateway class.
      */
     public function __construct() {
@@ -228,6 +253,8 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
         $this->set_api_credentials();
         $this->set_max_and_min_amounts();
         $this->add_actions();
+
+        self::$instance = $this;
     }
 
     /**
@@ -288,9 +315,15 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
      * @return void
      */
     protected function add_actions() {
+        if( static::$actions_added ) {
+            return false;
+        }
+
         add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
         add_action( 'woocommerce_thankyou_laskuhari', array( $this, 'thankyou_page' ) );
         add_action( 'woocommerce_email_before_order_table', array( $this, 'email_instructions' ), 10, 3 );
+
+        static::$actions_added = true;
     }
 
     /**

--- a/test/puppeteer/checkout-change-order-status-when-invoicing.test.js
+++ b/test/puppeteer/checkout-change-order-status-when-invoicing.test.js
@@ -79,4 +79,4 @@ test("checkout-change-order-status-when-invoicing", async () => {
 
     // close browser
     await browser.close();
-}, 100000);
+}, 600000);

--- a/test/puppeteer/checkout-create-and-send-as-attachment.test.js
+++ b/test/puppeteer/checkout-create-and-send-as-attachment.test.js
@@ -78,4 +78,4 @@ test("checkout-create-and-send-as-attachment", async () => {
 
     // close browser
     await browser.close();
-}, 100000);
+}, 600000);

--- a/test/puppeteer/checkout-create-and-send.test.js
+++ b/test/puppeteer/checkout-create-and-send.test.js
@@ -77,4 +77,4 @@ test("checkout-create-and-send", async () => {
 
     // close browser
     await browser.close();
-}, 100000);
+}, 600000);

--- a/test/puppeteer/checkout-create-dont-send.test.js
+++ b/test/puppeteer/checkout-create-dont-send.test.js
@@ -75,4 +75,4 @@ test("checkout-create-dont-send", async () => {
 
     // close browser
     await browser.close();
-}, 100000);
+}, 600000);

--- a/test/puppeteer/checkout-disable-sending-methods.test.js
+++ b/test/puppeteer/checkout-disable-sending-methods.test.js
@@ -126,4 +126,4 @@ test("checkout-disable-sending-methods", async () => {
 
     // close browser
     await browser.close();
-}, 100000);
+}, 600000);

--- a/test/puppeteer/checkout-dont-create-dont-send.test.js
+++ b/test/puppeteer/checkout-dont-create-dont-send.test.js
@@ -72,4 +72,4 @@ test("checkout-dont-create-dont-send", async () => {
 
     // close browser
     await browser.close();
-}, 100000);
+}, 600000);

--- a/test/puppeteer/checkout-einvoice.test.js
+++ b/test/puppeteer/checkout-einvoice.test.js
@@ -122,4 +122,4 @@ test("checkout-einvoice", async () => {
 
     // close browser
     await browser.close();
-}, 100000);
+}, 600000);

--- a/test/puppeteer/checkout-letter.test.js
+++ b/test/puppeteer/checkout-letter.test.js
@@ -98,4 +98,4 @@ test("checkout-letter", async () => {
 
     // close browser
     await browser.close();
-}, 100000);
+}, 600000);

--- a/test/puppeteer/checkout-only-for-billing-customers.test.js
+++ b/test/puppeteer/checkout-only-for-billing-customers.test.js
@@ -199,4 +199,4 @@ test("checkout-only-for-billing-customers", async () => {
 
     // close browser
     await browser.close();
-}, 100000);
+}, 600000);

--- a/test/puppeteer/checkout-with-invoicing-fee.test.js
+++ b/test/puppeteer/checkout-with-invoicing-fee.test.js
@@ -77,4 +77,4 @@ test("checkout-with-invoicing-fee", async () => {
 
     // close browser
     await browser.close();
-}, 100000);
+}, 600000);

--- a/test/puppeteer/manual-order.test.js
+++ b/test/puppeteer/manual-order.test.js
@@ -150,4 +150,4 @@ test("manual-order", async () => {
 
     // close browser
     await browser.close();
-}, 100000);
+}, 600000);

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Laskuhari for WooCommerce
 Plugin URI: https://www.laskuhari.fi/woocommerce-laskutus
 Description: Lisää automaattilaskutuksen maksutavaksi WooCommerce-verkkokauppaan sekä mahdollistaa tilausten manuaalisen laskuttamisen
-Version: 1.7.1
+Version: 1.7.2
 Author: Datahari Solutions
 Author URI: https://www.datahari.fi
 License: GPLv2
@@ -134,7 +134,7 @@ function laskuhari_maybe_create_webhook() {
 }
 
 function laskuhari_get_gateway_object() {
-    return WC()->payment_gateways->payment_gateways()["laskuhari"];
+    return WC_Gateway_Laskuhari::get_instance();
 }
 
 function laskuhari_domain() {


### PR DESCRIPTION
**Fixed compatibility issue with Paytrail for WooCommerce plugin**
Version 1.7 and 1.7.1 loaded the `WC()->payment_gateways` at the action `woocommerce_after_register_post_types` and this was not compatible with the Paytrail for WooCommerce plugin and made it so that the order status was saved as `processing` in the database after a successful Paytrail payment, instead of `wc-processing`.