### PR TITLE
Released version 1.7.4

### DIFF
--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Laskuhari for WooCommerce
 Plugin URI: https://www.laskuhari.fi/woocommerce-laskutus
 Description: Lisää automaattilaskutuksen maksutavaksi WooCommerce-verkkokauppaan sekä mahdollistaa tilausten manuaalisen laskuttamisen
-Version: 1.7.3
+Version: 1.7.4
 Author: Datahari Solutions
 Author URI: https://www.datahari.fi
 License: GPLv2
@@ -2670,7 +2670,7 @@ function laskuhari_process_action( $order_id, $send = false, $bulk_action = fals
     }
 
     // lisätään alennus
-    if( abs( round( $cart_discount, 2 ) ) > 0 ) {
+    if( round( $cart_discount, 2 ) > 0 && round( $cart_discount_tax, 2 ) >= 0 ) {
         $discount_name = "Alennus";
 
         $coupon_count = count( $coupon_codes );


### PR DESCRIPTION
**Fixed problem in cart discount calculation**
In some cases the cart discount or cart discount tax is not a positive number. This causes unexpected behavior in the calculation of the discount row. The discount row is now only added if the cart discount and cart discount tax are both positive numbers.