### PR TITLE
Released version 1.9.0

### DIFF
--- a/scripts/create_package.sh
+++ b/scripts/create_package.sh
@@ -30,6 +30,10 @@ rm -rf woocommerce-laskuhari-payment-gateway/scripts
 # remove config
 rm -rf woocommerce-laskuhari-payment-gateway/config
 
+# remove composer files
+rm -f woocommerce-laskuhari-payment-gateway/composer.json
+rm -f woocommerce-laskuhari-payment-gateway/composer.lock
+
 # get version number
 VERSION=`grep "Version: " woocommerce-laskuhari-payment-gateway/woocommerce-laskuhari-payment-gateway.php | awk '{print $2}'`
 

--- a/src/WC_Gateway_Laskuhari.php
+++ b/src/WC_Gateway_Laskuhari.php
@@ -204,6 +204,14 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
     public $attach_invoice_to_wc_email;
 
     /**
+     * Whether to attach receipt of payment from other
+     * payment methods to WooCommerce emails
+     *
+     * @var bool
+     */
+    public $attach_receipt_to_wc_email;
+
+    /**
      * Whether to add a paid stamp to the invoice
      *
      * @var bool
@@ -309,6 +317,7 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
         $this->send_invoice_from_payment_methods            = (array)$this->lh_get_option( 'send_invoice_from_payment_methods', array() );
         $this->invoice_email_text_for_other_payment_methods = trim(rtrim($this->lh_get_option( 'invoice_email_text_for_other_payment_methods' )));
         $this->attach_invoice_to_wc_email                   = $this->lh_get_option( 'attach_invoice_to_wc_email' ) === "yes";
+        $this->attach_receipt_to_wc_email                   = $this->lh_get_option( 'attach_receipt_to_wc_email', 'yes' ) === "yes";
         $this->paid_stamp                                   = $this->lh_get_option( 'paid_stamp' ) === "yes";
         $this->receipt_template                             = $this->lh_get_option( 'receipt_template' ) === "yes";
     }
@@ -843,6 +852,12 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                 'custom_attributes' => array(
                     'data-placeholder' => __( 'Valitse maksutavat', 'laskuhari' )
                 )
+            ),
+            'attach_receipt_to_wc_email' => array(
+                'title'       => __( 'Lähetä', 'laskuhari' ),
+                'label'       => __( 'Liitä muilla maksutavoilla maksettujen tilausten tilausvahvistuksen liiteeksi lasku', 'laskuhari' ),
+                'type'        => 'checkbox',
+                'default'     => 'yes'
             ),
             'status_after_gateway' => array(
                 'title'       => __( 'Tilauksen tila laskutuksen jälkeen', 'laskuhari' ),

--- a/src/WC_Gateway_Laskuhari.php
+++ b/src/WC_Gateway_Laskuhari.php
@@ -684,6 +684,11 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                 'description' => '',
                 'default'     => 'no'
             ),
+            'heading_payment_gateway' => array(
+                'title'       => __( 'Maksutapa', 'laskuhari' ),
+                'type'        => 'title',
+                'description' => '',
+            ),
             'gateway_enabled' => array(
                 'title'       => __( 'Maksutapa', 'laskuhari' ),
                 'label'       => __( 'Ota käyttöön Laskutus-maksutapa', 'laskuhari' ),
@@ -712,6 +717,11 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                 'description' => 'Sähköpostilaskua ei tässä tapauksessa lähetetä erikseen',
                 'default'     => 'no'
             ),
+            'heading_billing_methods' => array(
+                'title'       => __( 'Laskutustavat', 'laskuhari' ),
+                'type'        => 'title',
+                'description' => '',
+            ),
             'email_lasku_kaytossa' => array(
                 'title'       => __( 'Sähköpostilaskut käytössä', 'laskuhari' ),
                 'label'       => __( 'Ota käyttöön sähköpostilaskut', 'laskuhari' ),
@@ -733,6 +743,23 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                 'description' => '',
                 'default'     => 'yes'
             ),
+            'send_method_fallback' => array(
+                'title'       => __( 'Lähetystapa (fallback)', 'laskuhari' ),
+                'label'       => __( 'Valitse laskujen lähetystapa', 'laskuhari' ),
+                'type'        => 'select',
+                'description' => __( 'Valitse tapa, jolla haluat lähettää laskut, joiden lähetystapaa ei ole valittu', 'laskuhari' ),
+                'default'     => $this->lh_get_option( 'lahetystapa_manuaalinen', 'ei' ),
+                'options'     => array(
+                    'email' => __( 'Sähköpostilasku', 'laskuhari' ),
+                    'kirje' => __( 'Kirjelasku', 'laskuhari' ),
+                    'ei'    => __( 'Tallenna Laskuhariin, älä lähetä', 'laskuhari' )
+                )
+            ),
+            'heading_sync' => array(
+                'title'       => __( 'Synkronointi', 'laskuhari' ),
+                'type'        => 'title',
+                'description' => '',
+            ),
             'synkronoi_varastosaldot' => array(
                 'title'       => __( 'Synkronoi varastosaldot', 'laskuhari' ),
                 'label'       => __( 'Pidä varastosaldot Laskuharin ja WooCommercen välillä ajan tasalla', 'laskuhari' ),
@@ -747,6 +774,11 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                 'description' => '',
                 'default'     => 'no'
             ),
+            'heading_api_settings' => array(
+                'title'       => __( 'Rajapintatiedot', 'laskuhari' ),
+                'type'        => 'title',
+                'description' => '',
+            ),
             'uid' => array(
                 'title'       => __( 'UID', 'laskuhari' ),
                 'type'        => 'text',
@@ -755,9 +787,14 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
             ),
             'apikey' => array(
                 'title'       => __( 'API-koodi', 'laskuhari' ),
-                'type'        => 'text',
+                'type'        => 'password',
                 'description' => 'Laskuhari-tunnuksesi API-koodi (kysy asiakaspalvelusta)',
                 'default'     => __( '', 'laskuhari' ),
+            ),
+            'heading_demo' => array(
+                'title'       => __( 'Demotila', 'laskuhari' ),
+                'type'        => 'title',
+                'description' => '',
             ),
             'demotila' => array(
                 'title'       => __( 'Demotila', 'laskuhari' ),
@@ -766,17 +803,10 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                 'description' => 'Demotilassa et tarvitse UID- tai API-koodia. Voit lähettää vain sähköpostilaskuja, ja ne lähetetään testiyrityksen tiedoilla. Jos haluat oman yrityksesi tiedot laskulle, luo tunnukset <a href="https://www.laskuhari.fi" target="_blank">Laskuhari.fi</a>-palveluun ja liitä UID ja API-koodi lisäosan asetuksiin sekä poista demotila käytöstä.',
                 'default'     => 'yes'
             ),
-            'send_method_fallback' => array(
-                'title'       => __( 'Lähetystapa (fallback)', 'laskuhari' ),
-                'label'       => __( 'Valitse laskujen lähetystapa', 'laskuhari' ),
-                'type'        => 'select',
-                'description' => __( 'Valitse tapa, jolla haluat lähettää laskut, joiden lähetystapaa ei ole valittu', 'laskuhari' ),
-                'default'     => $this->lh_get_option( 'lahetystapa_manuaalinen', 'ei' ),
-                'options'     => array(
-                    'email' => __( 'Sähköpostilasku', 'laskuhari' ),
-                    'kirje' => __( 'Kirjelasku', 'laskuhari' ),
-                    'ei'    => __( 'Tallenna Laskuhariin, älä lähetä', 'laskuhari' )
-                )
+            'heading_texts' => array(
+                'title'       => __( 'Tekstit', 'laskuhari' ),
+                'type'        => 'title',
+                'description' => '',
             ),
             'laskuviesti' => array(
                 'title'       => __( 'Laskuviesti', 'laskuhari' ),
@@ -813,6 +843,11 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                 'default'     => __( 'Lähetämme sinulle laskun tilauksestasi.', 'laskuhari' ),
                 'desc_tip'    => true,
             ),
+            'heading_billing_fee' => array(
+                'title'       => __( 'Laskutuslisä', 'laskuhari' ),
+                'type'        => 'title',
+                'description' => '',
+            ),
             'laskutuslisa' => array(
                 'title'       => __( 'Laskutuslisä', 'laskuhari' ),
                 'type'        => 'text',
@@ -827,6 +862,11 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                 'default'     => __( '24', 'laskuhari' ),
                 'desc_tip'    => true,
             ),
+            'heading_shipping_methods' => array(
+                'title'       => __( 'Toimitustavat', 'laskuhari' ),
+                'type'        => 'title',
+                'description' => '',
+            ),
             'enable_for_methods' => array(
                 'title'             => __( 'Käytössä näille toimitustavoille', 'laskuhari' ),
                 'type'              => 'multiselect',
@@ -840,13 +880,17 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                     'data-placeholder' => __( 'Valitse toimitustavat', 'laskuhari' )
                 )
             ),
+            'heading_payment_methods' => array(
+                'title'       => __( 'Tee lasku/kuitti muilla maksutavoilla tehdyistä tilauksista', 'laskuhari' ),
+                'type'        => 'title',
+                'description' => __( 'Tällä toiminnolla voit lähettää esim. verkkomaksuista laskun asiakkaalle kuittina maksusta', 'laskuhari' ),
+            ),
             'send_invoice_from_payment_methods' => array(
-                'title'             => __( 'Lähetä lasku myös näistä maksutavoista', 'laskuhari' ),
+                'title'             => __( 'Luo lasku myös näistä maksutavoista', 'laskuhari' ),
                 'type'              => 'multiselect',
                 'class'             => 'wc-enhanced-select',
                 'css'               => 'width: 450px;',
                 'default'           => '',
-                'description'       => __( 'Tällä toiminnolla voit lähettää esim. verkkomaksuista laskun asiakkaalle kuittina maksusta (lähetetään tilausvahvistuksen liitteenä)', 'laskuhari' ),
                 'options'           => [],
                 'desc_tip'          => true,
                 'custom_attributes' => array(
@@ -858,6 +902,30 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                 'label'       => __( 'Liitä muilla maksutavoilla maksettujen tilausten tilausvahvistuksen liiteeksi lasku', 'laskuhari' ),
                 'type'        => 'checkbox',
                 'default'     => 'yes'
+            ),
+            'paid_stamp' => array(
+                'title'             => __( 'Maksettu-leima', 'laskuhari' ),
+                'label'             => __( 'Lisää maksettu-leima muilla maksutavoilla maksettuihin laskuihin', 'laskuhari' ),
+                'type'              => 'checkbox',
+                'default'           => 'no'
+            ),
+            'receipt_template' => array(
+                'title'             => __( 'Lähetä kuittina', 'laskuhari' ),
+                'label'             => __( 'Käytä kuittipohjaa laskupohjan sijasta muilla maksutavoilla maksetuissa tilauksissa', 'laskuhari' ),
+                'type'              => 'checkbox',
+                'default'           => 'no'
+            ),
+            'invoice_email_text_for_other_payment_methods' => array(
+                'title'       => __( 'Laskuviesti (muu maksutapa)', 'laskuhari' ),
+                'type'        => 'textarea',
+                'description' => __( 'Teksti, joka lisätään tilausvahvistusviestiin, kun tilaus on maksettu muuta maksutapaa käyttäen', 'laskuhari' ),
+                'default'     => __( 'Liitteenä laskukopio kuittina tilaamistasi tuotteista.', 'laskuhari' ),
+                'desc_tip'    => true,
+            ),
+            'heading_order_status' => array(
+                'title'       => __( 'Tilauksen tila', 'laskuhari' ),
+                'type'        => 'title',
+                'description' => '',
             ),
             'status_after_gateway' => array(
                 'title'       => __( 'Tilauksen tila laskutuksen jälkeen', 'laskuhari' ),
@@ -884,24 +952,10 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
                     'on-hold' => __( 'Jonossa', 'laskuhari' )
                 )
             ),
-            'paid_stamp' => array(
-                'title'             => __( 'Maksettu-leima', 'laskuhari' ),
-                'label'             => __( 'Lisää maksettu-leima muilla maksutavoilla maksettuihin laskuihin', 'laskuhari' ),
-                'type'              => 'checkbox',
-                'default'           => 'no'
-            ),
-            'receipt_template' => array(
-                'title'             => __( 'Lähetä kuittina', 'laskuhari' ),
-                'label'             => __( 'Käytä kuittipohjaa laskupohjan sijasta muilla maksutavoilla maksetuissa tilauksissa', 'laskuhari' ),
-                'type'              => 'checkbox',
-                'default'           => 'no'
-            ),
-            'invoice_email_text_for_other_payment_methods' => array(
-                'title'       => __( 'Laskuviesti (muu maksutapa)', 'laskuhari' ),
-                'type'        => 'textarea',
-                'description' => __( 'Teksti, joka lisätään tilausvahvistusviestiin, kun tilaus on maksettu muuta maksutapaa käyttäen', 'laskuhari' ),
-                'default'     => __( 'Liitteenä laskukopio kuittina tilaamistasi tuotteista.', 'laskuhari' ),
-                'desc_tip'    => true,
+            'heading_misc' => array(
+                'title'       => __( 'Sekalaiset', 'laskuhari' ),
+                'type'        => 'title',
+                'description' => '',
             ),
             'salli_laskutus_erikseen' => array(
                 'title'       => __( 'Salli vain laskutusasiakkaille', 'laskuhari' ),

--- a/test/puppeteer/checkout-with-paytrail-with-attachment.test.js
+++ b/test/puppeteer/checkout-with-paytrail-with-attachment.test.js
@@ -1,0 +1,87 @@
+const puppeteer = require('puppeteer');
+const functions = require('./functions.js');
+const config = require('./config.js');
+
+/**
+ * Test sending an invoice as attachment along with an order that is paid
+ * with the Paytrail payment method.
+ */
+
+test("checkout-with-paytrail", async () => {
+    const browser = await puppeteer.launch({
+        headless: config.headless,
+        defaultViewport: {
+            width: 1452,
+            height: 768
+        },
+        args:[
+            '--start-maximized'
+        ]
+    });
+
+    const page = await browser.newPage();
+    await page.setDefaultNavigationTimeout( 60000 );
+
+    page.on("pageerror", function(err) {
+            theTempValue = err.toString();
+            console.log("Page error: " + theTempValue);
+            browser.close();
+    });
+
+    // log in to plugin settings page
+    await functions.open_settings( page );
+
+    // reset settings
+    await functions.reset_settings( page );
+
+    // select settings
+    await page.evaluate( function() {
+        let $ = jQuery;
+        $("#woocommerce_laskuhari_send_invoice_from_payment_methods option[value='paytrail']").attr( "selected", true );
+        $("#woocommerce_laskuhari_attach_receipt_to_wc_email").prop( "checked", true );
+        $("#woocommerce_laskuhari_auto_gateway_create_enabled").prop( "checked", true );
+        $("#woocommerce_laskuhari_auto_gateway_enabled").prop( "checked", false );
+        $("#woocommerce_laskuhari_laskuviesti").val(
+            $("#woocommerce_laskuhari_laskuviesti").val() +
+            " (paytrail-with-attachment-test)"
+        );
+        $("#woocommerce_laskuhari_instructions").val(
+            $("#woocommerce_laskuhari_instructions").val() +
+            " (paytrail-with-attachment-test)"
+        );
+    } );
+
+    // save settings
+    await page.click( ".woocommerce-save-button" );
+
+    // wait for settings to be saved
+    await page.waitForNavigation();
+    await page.waitForSelector( ".updated.inline" );
+
+    // log out
+    await functions.logout( page );
+
+    // make an order
+    await functions.add_product_to_cart_and_go_to_checkout( page );
+    await functions.fill_out_checkout_form( page );
+    await functions.select_paytrail_payment_method( page );
+    await functions.place_order( page );
+
+    // wait for order to be placed
+    await page.waitForSelector( ".woocommerce-order-received" );
+
+    // grab order id
+    let order_id = await functions.grab_order_id( page );
+
+    // go to orders list
+    await page.goto( config.wordpress_url + "/wp-admin/edit.php?post_type=shop_order" );
+    await functions.login( page, config.wordpress_user, config.wordpress_password );
+
+    // check that the order was added to the list
+    await functions.wait_for_loading( page );
+    let element = await page.$('#post-'+order_id);
+    expect(element).toBeTruthy();
+
+    // close browser
+    await browser.close();
+}, 600000);

--- a/test/puppeteer/checkout-with-paytrail-without-attachment.test.js
+++ b/test/puppeteer/checkout-with-paytrail-without-attachment.test.js
@@ -1,0 +1,86 @@
+const puppeteer = require('puppeteer');
+const functions = require('./functions.js');
+const config = require('./config.js');
+
+/**
+ * Test creating an invoice from an order paid with the Paytrail payment method
+ * (creates invoice but doesn't send it)
+ */
+
+test("checkout-with-paytrail", async () => {
+    const browser = await puppeteer.launch({
+        headless: config.headless,
+        defaultViewport: {
+            width: 1452,
+            height: 768
+        },
+        args:[
+            '--start-maximized'
+        ]
+    });
+
+    const page = await browser.newPage();
+    await page.setDefaultNavigationTimeout( 60000 );
+
+    page.on("pageerror", function(err) {
+            theTempValue = err.toString();
+            console.log("Page error: " + theTempValue);
+            browser.close();
+    });
+
+    // log in to plugin settings page
+    await functions.open_settings( page );
+
+    // reset settings
+    await functions.reset_settings( page );
+
+    // select settings
+    await page.evaluate( function() {
+        let $ = jQuery;
+        $("#woocommerce_laskuhari_send_invoice_from_payment_methods option[value='paytrail']").attr( "selected", true );
+        $("#woocommerce_laskuhari_auto_gateway_create_enabled").prop( "checked", true );
+        $("#woocommerce_laskuhari_auto_gateway_enabled").prop( "checked", false );
+        $("#woocommerce_laskuhari_laskuviesti").val(
+            $("#woocommerce_laskuhari_laskuviesti").val() +
+            " (paytrail-no-attachment-test)"
+        );
+        $("#woocommerce_laskuhari_instructions").val(
+            $("#woocommerce_laskuhari_instructions").val() +
+            " (paytrail-no-attachment-test)"
+        );
+    } );
+
+    // save settings
+    await page.click( ".woocommerce-save-button" );
+
+    // wait for settings to be saved
+    await page.waitForNavigation();
+    await page.waitForSelector( ".updated.inline" );
+
+    // log out
+    await functions.logout( page );
+
+    // make an order
+    await functions.add_product_to_cart_and_go_to_checkout( page );
+    await functions.fill_out_checkout_form( page );
+    await functions.select_paytrail_payment_method( page );
+    await functions.place_order( page );
+
+    // wait for order to be placed
+    await page.waitForSelector( ".woocommerce-order-received" );
+
+    // grab order id
+    let order_id = await functions.grab_order_id( page );
+
+    // go to orders list
+    await page.goto( config.wordpress_url + "/wp-admin/edit.php?post_type=shop_order" );
+    await functions.login( page, config.wordpress_user, config.wordpress_password );
+
+    // check that the order was added to the list
+    await functions.wait_for_loading( page );
+    let element = await page.$('#post-'+order_id);
+    expect(element).toBeTruthy();
+
+    // close browser
+    await browser.close();
+}, 600000);

--- a/test/puppeteer/functions.js
+++ b/test/puppeteer/functions.js
@@ -225,8 +225,9 @@ exports.reset_settings = async function( page ) {
         $("#woocommerce_laskuhari_instructions").val("We will send you an invoice");
         $("#woocommerce_laskuhari_laskutuslisa").val("0");
         $("#woocommerce_laskuhari_laskutuslisa_alv").val("0");
-        $("#woocommerce_laskuhari_enable_for_methods option").prop("selected", false);
-        $("#woocommerce_laskuhari_send_invoice_from_payment_methods option").prop("selected", false);
+        $("#woocommerce_laskuhari_enable_for_methods option").attr("selected", false);
+        $("#woocommerce_laskuhari_send_invoice_from_payment_methods option").attr("selected", false);
+        $("#woocommerce_laskuhari_attach_receipt_to_wc_email").prop( "checked", false );
         $("#woocommerce_laskuhari_paid_stamp").prop( "checked", false );
         $("#woocommerce_laskuhari_receipt_template").prop( "checked", false );
         $("#woocommerce_laskuhari_invoice_email_text_for_other_payment_methods").val("Attached you will find an invoice as a receipt");

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Laskuhari for WooCommerce
 Plugin URI: https://www.laskuhari.fi/woocommerce-laskutus
 Description: Lisää automaattilaskutuksen maksutavaksi WooCommerce-verkkokauppaan sekä mahdollistaa tilausten manuaalisen laskuttamisen
-Version: 1.8.1
+Version: 1.9.0
 Author: Datahari Solutions
 Author URI: https://www.datahari.fi
 License: GPLv2

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -253,7 +253,7 @@ function laskuhari_handle_payment_complete( $order_id ) {
     update_post_meta( $order_id, '_laskuhari_paid_by_other', "yes" );
 
     // create invoice only if no invoice has been created yet
-    $create_invoice = boolval( laskuhari_invoice_number_by_order( $order_id ) );
+    $create_invoice = ! laskuhari_invoice_number_by_order( $order_id );
 
     // allow changing invoice creation logic by other plugins
     $create_invoice = apply_filters( "laskuhari_handle_payment_complete_create_invoice", $create_invoice, $order_id );

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -259,7 +259,11 @@ function laskuhari_handle_payment_complete( $order_id ) {
     $create_invoice = apply_filters( "laskuhari_handle_payment_complete_create_invoice", $create_invoice, $order_id );
 
     if( $create_invoice ) {
-        laskuhari_process_action( $order_id, false );
+        if( $laskuhari_gateway_object->attach_receipt_to_wc_email ) {
+            laskuhari_process_action( $order_id, false );
+        } else {
+            laskuhari_process_action_delayed( $order_id, false );
+        }
     }
 }
 

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -2179,10 +2179,12 @@ function laskuhari_maybe_send_invoice_attached( $order ) {
         return false;
     }
 
-    // attach invoice pdf to WC email
-    if( $laskuhari_gateway_object->attach_receipt_to_wc_email ) {
-        laskuhari_send_invoice_attached( $order );
+    if( ! $laskuhari_gateway_object->attach_receipt_to_wc_email && $order->get_payment_method() !== "laskuhari" ) {
+        return false;
     }
+
+    // attach invoice pdf to WC email
+    laskuhari_send_invoice_attached( $order );
 }
 
 function laskuhari_send_invoice_attached( $order ) {

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -2176,7 +2176,9 @@ function laskuhari_maybe_send_invoice_attached( $order ) {
     }
 
     // attach invoice pdf to WC email
-    laskuhari_send_invoice_attached( $order );
+    if( $laskuhari_gateway_object->attach_receipt_to_wc_email ) {
+        laskuhari_send_invoice_attached( $order );
+    }
 }
 
 function laskuhari_send_invoice_attached( $order ) {

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -252,7 +252,15 @@ function laskuhari_handle_payment_complete( $order_id ) {
 
     update_post_meta( $order_id, '_laskuhari_paid_by_other', "yes" );
 
-    laskuhari_process_action( $order_id, false );
+    // create invoice only if no invoice has been created yet
+    $create_invoice = boolval( laskuhari_invoice_number_by_order( $order_id ) );
+
+    // allow changing invoice creation logic by other plugins
+    $create_invoice = apply_filters( "laskuhari_handle_payment_complete_create_invoice", $create_invoice, $order_id );
+
+    if( $create_invoice ) {
+        laskuhari_process_action( $order_id, false );
+    }
 }
 
 add_action( 'restrict_manage_posts', 'display_admin_shop_order_laskuhari_filter' );


### PR DESCRIPTION
**Fixed duplicate invoice creation with Paytrail plugin**
When creating invoices as receipts from Paytrail payments, the invoice was sometimes created two times due to how the Paytrail plugin handles callbacks of payment completion. New invoices will no longer be generated on orders that are paid with Paytrail or other non-Laskuhari payment methods if an invoice has already been created for that order. This doesn't fix the issue that the order confirmation will be sent twice, but there will be no two different invoices sent anymore. Paytrail has been notified about this problem and a [fix](https://github.com/paytrail/paytrail-for-woocommerce/pull/90) has been proposed.

**Added option to create but not send invoice from other payment methods**
Previously it was only possible to have the plugin create invoices **and** send them as an order confirmation email attachment when using other payment methods. Now the creation of invoices and sending them as an attachment when using other payment methods has been separated into different settings.

**Added headings to plugin settings**
The plugin settings page is starting to have a lot of settings, so the settings have been separated under different headings in order to make them more readable.