### PR TITLE
Released version 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Support for the new 25.5 % VAT (and future VAT rates with decimals)
+- End-to-end tests for orders with different VAT percentages
+- End-to-end tests for checking that invoice amounts match order amounts
+
+### Changed
+
+- Coupon discounts are now added per VAT rate when order includes products with various VAT rates
+- The product price of an order line item is now read directly from the item meta, not from the product database

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.12.0] 2024-05-10
 
 ### Added
 

--- a/test/phpunit/tests/Laskuhari_VAT_Test.php
+++ b/test/phpunit/tests/Laskuhari_VAT_Test.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * PHPUnit tests for VAT calculations
+ */
+
+class Laskuhari_VAT_Test extends \PHPUnit\Framework\TestCase
+{
+    protected function setUp(): void {
+        add_filter( "laskuhari_common_vat_rates", function( $vat_rates ) {
+            return array_merge( $vat_rates, [26.59] ); // You never know...
+        } );
+    }
+
+    /**
+     * Test that the VAT is calculated correctly
+     *
+     * @return void
+     */
+    public function test_it_calculates_vat_correctly() {
+        for( $price = 1; $price < 1000; $price += 0.01 ) {
+            $with_tax = round( $price * 1.24, 2 );
+            $this->assertEquals( 24, laskuhari_vat_percent( ($with_tax / $price - 1) * 100 ) );
+
+            $with_tax = round( $price * 1.255, 2 );
+            $this->assertEquals( 25.5, laskuhari_vat_percent( ($with_tax / $price - 1) * 100 ) );
+
+            // You never know...
+            $with_tax = round( $price * 1.2659, 2 );
+            $this->assertEquals( 26.59, laskuhari_vat_percent( ($with_tax / $price - 1) * 100 ) );
+        }
+    }
+
+    /**
+     * Test that the VAT is calculated correctly with small numbers
+     *
+     * @return void
+     */
+    public function test_it_calculates_vat_correctly_with_small_numbers() {
+        for( $price = 0.01; $price < 1; $price += 0.01 ) {
+            $with_tax = round( $price * 1.24, 4 );
+            $this->assertEquals( 24, laskuhari_vat_percent( ($with_tax / $price - 1) * 100 ) );
+
+            $with_tax = round( $price * 1.255, 4 );
+            $this->assertEquals( 25.5, laskuhari_vat_percent( ($with_tax / $price - 1) * 100 ) );
+
+            // You never know...
+            $with_tax = round( $price * 1.2659, 4 );
+            $this->assertEquals( 26.59, laskuhari_vat_percent( ($with_tax / $price - 1) * 100 ) );
+        }
+    }
+}

--- a/test/puppeteer/checkout-create-dont-send.test.js
+++ b/test/puppeteer/checkout-create-dont-send.test.js
@@ -63,6 +63,9 @@ test("checkout-create-dont-send", async () => {
     // open order page
     await functions.open_order_page( page );
 
+    // get order id from url
+    const order_id = await functions.get_order_id( page );
+
     // check that invoice created but not sent
     let element = await page.$('.laskuhari-tila');
     let invoice_status = await page.evaluate(el => el.textContent, element);
@@ -73,6 +76,9 @@ test("checkout-create-dont-send", async () => {
 
     // wait for a while so we can inspect the result
     await functions.sleep( 5000 );
+
+    // check amounts
+    await functions.check_invoice_amounts( page, order_id, 18, 4.32, 22.32 );
 
     // close browser
     await browser.close();

--- a/test/puppeteer/checkout-with-invoicing-fee.test.js
+++ b/test/puppeteer/checkout-with-invoicing-fee.test.js
@@ -65,6 +65,9 @@ test("checkout-with-invoicing-fee", async () => {
     // open order page
     await functions.open_order_page( page );
 
+    // get order id from url
+    const order_id = await functions.get_order_id( page );
+
     // check that invoicing fee was added
     let element = await page.$('#order_fee_line_items .name .view');
     let invoice_status = await page.evaluate(el => el.textContent, element);
@@ -75,6 +78,9 @@ test("checkout-with-invoicing-fee", async () => {
 
     // wait for a while so we can inspect the result
     await functions.sleep( 8000 );
+
+    // check amounts
+    await functions.check_invoice_amounts( page, order_id, 19.65, 4.72, 24.37 );
 
     // close browser
     await browser.close();

--- a/test/puppeteer/functions.js
+++ b/test/puppeteer/functions.js
@@ -225,6 +225,20 @@ exports.reset_settings = async function( page ) {
     } );
 }
 
+exports.add_coupon_to_order = async function( page, coupon_code ) {
+    const set_coupon_code = dialog => {
+        dialog.accept( coupon_code );
+    }
+
+    page.on('dialog', set_coupon_code);
+
+    // click "Add coupon"
+    await page.click( ".button.add-coupon" );
+    await exports.sleep( 600 );
+
+    page.off('dialog', set_coupon_code);
+}
+
 exports.add_product_to_order = async function( page, product_name, quantity = 1 ) {
     // click "Add line item"
     await page.click( ".button.add-line-item" );

--- a/test/puppeteer/manual-order.test.js
+++ b/test/puppeteer/manual-order.test.js
@@ -129,6 +129,9 @@ test("manual-order", async () => {
     await page.waitForNavigation();
     await page.waitForSelector( ".laskuhari-payment-status" );
 
+    // get order id from url
+    const order_id = await functions.get_order_id( page );
+
     // check that an invoice was sent
     element = await page.$('.laskuhari-tila');
     invoice_status = await page.evaluate(el => el.textContent, element);
@@ -149,6 +152,9 @@ test("manual-order", async () => {
 
     // wait for a while so we can assess the results
     await functions.sleep( 6000 );
+
+    // check amounts
+    await functions.check_invoice_amounts( page, order_id, 46.43, 11.14, 57.57 );
 
     // close browser
     await browser.close();

--- a/test/puppeteer/quantity-units.test.js
+++ b/test/puppeteer/quantity-units.test.js
@@ -99,11 +99,18 @@ test("quantity-units", async () => {
     // wait for page to load
     await page.waitForSelector( ".laskuhari-payment-status" );
 
+    // get order id from url
+    const order_id = await functions.get_order_id( page );
+
     // open invoice pdf
     await functions.open_invoice_pdf( page );
 
     // wait for a while so we can assess the results
     await functions.sleep( 6000 );
+
+    // check amounts
+    // NOTE: zero VAT as we don't "recalculate"
+    await functions.check_invoice_amounts( page, order_id, 25, 0, 25 );
 
     // close browser
     await browser.close();

--- a/test/puppeteer/rounding-issues-2.test.js
+++ b/test/puppeteer/rounding-issues-2.test.js
@@ -102,6 +102,9 @@ test("rounding-issues-2", async () => {
     // wait for page to load
     await page.waitForSelector( "#laskuhari_metabox" );
 
+    // get order id from url
+    const order_id = await functions.get_order_id( page );
+
     // check that invoice was not created
     let element = await page.$('.laskuhari-tila');
     let invoice_status = await page.evaluate(el => el.textContent, element);
@@ -126,6 +129,9 @@ test("rounding-issues-2", async () => {
 
     // wait for a while so we can assess the results
     await functions.sleep( 10000 );
+
+    // check amounts
+    await functions.check_invoice_amounts( page, order_id, 162, 38.88, 200.88 );
 
     // close browser
     await browser.close();

--- a/test/puppeteer/rounding-issues.test.js
+++ b/test/puppeteer/rounding-issues.test.js
@@ -129,11 +129,17 @@ test("rounding-issues", async () => {
     // wait for page to load
     await page.waitForSelector( ".laskuhari-payment-status" );
 
+    // get order id from url
+    const order_id = await functions.get_order_id( page );
+
     // open invoice pdf
     await functions.open_invoice_pdf( page );
 
     // wait for a while so we can assess the results
     await functions.sleep( 6000 );
+
+    // check amounts
+    await functions.check_invoice_amounts( page, order_id, 283.81, 68.11, 351.92 );
 
     // close browser
     await browser.close();

--- a/test/puppeteer/vat-percentages-25.5.test.js
+++ b/test/puppeteer/vat-percentages-25.5.test.js
@@ -103,11 +103,17 @@ test("vat-percentages-25.5", async () => {
     // wait for page to load
     await page.waitForSelector( ".laskuhari-payment-status" );
 
+    // get order id from url
+    const order_id = await functions.get_order_id( page );
+
     // open invoice pdf
     await functions.open_invoice_pdf( page );
 
     // wait for a while so we can assess the results
     await functions.sleep( 10000 );
+
+    // check amounts
+    await functions.check_invoice_amounts( page, order_id, 10, 2.55, 12.55 );
 
     // close browser
     await browser.close();

--- a/test/puppeteer/vat-percentages-25.5.test.js
+++ b/test/puppeteer/vat-percentages-25.5.test.js
@@ -1,0 +1,114 @@
+const puppeteer = require('puppeteer');
+const functions = require('./functions.js');
+const config    = require('./config.js');
+
+/**
+ * This test checks that the plugin supports
+ * the new 25.5 % VAT percentage.
+ */
+
+test("vat-percentages-25.5", async () => {
+    const browser = await puppeteer.launch({
+        headless: config.headless,
+        defaultViewport: {
+            width: 1452,
+            height: 768
+        },
+        args:[
+            '--start-maximized'
+        ]
+    });
+
+    const page = await browser.newPage();
+    await page.setDefaultNavigationTimeout( 60000 );
+
+    page.on("pageerror", function(err) {
+            theTempValue = err.toString();
+            console.log("Page error: " + theTempValue);
+            browser.close();
+    });
+
+    // log in to plugin settings page
+    await functions.open_settings( page );
+
+    // reset settings
+    await functions.reset_settings( page );
+
+    // save settings
+    await page.click( ".woocommerce-save-button" );
+
+    // go to new order creation
+    await page.goto( config.wordpress_url + "/wp-admin/post-new.php?post_type=shop_order" );
+
+    // change status of order
+    await page.waitForSelector( "#order_status" );
+    await page.select( "#order_status", "wc-processing" );
+
+    // click billing address edit button
+    await page.waitForSelector( ".order_data_column a.edit_address" );
+    await page.click( ".order_data_column a.edit_address" );
+
+    // input customer details
+    await page.waitForSelector( "#_billing_first_name" );
+    await page.click( "#_billing_first_name" );
+    await page.keyboard.type( "Jack VAT 25.5" );
+    await page.click( "#_billing_last_name" );
+    await page.keyboard.type( "Smith" );
+    await page.click( "#_billing_address_1" );
+    await page.keyboard.type( "Jack's road" );
+    await page.click( "#_billing_city" );
+    await page.keyboard.type( "Jackcity" );
+    await page.click( "#_billing_postcode" );
+    await page.keyboard.type( "54321" );
+    await page.evaluate(() => document.getElementById("_billing_email").value="");
+    await page.click( "#_billing_email" );
+    await page.keyboard.type( config.test_email );
+
+    // Add testing products
+    await functions.add_product_to_order( page, "VAT 25.5 test 1" );
+
+    // prepare for confirmation dialog
+    page.off('dialog', functions.accept_dialog);
+    page.on('dialog', functions.accept_dialog);
+
+    // click on "calculate"
+    await page.click( ".button.button-primary.calculate-action" );
+
+    // wait for changes to take effect
+    await functions.sleep( 3000 );
+
+    // create order
+    await page.click( ".button.save_order.button-primary" );
+    await functions.sleep( 3000 );
+
+    // wait for page to load
+    await page.waitForSelector( "#laskuhari_metabox" );
+
+    // check that invoice was not created
+    let element = await page.$('.laskuhari-tila');
+    let invoice_status = await page.evaluate(el => el.textContent, element);
+    expect( invoice_status ).toBe( "EI LASKUTETTU" );
+
+    await functions.sleep( 600 );
+
+    // wait for "create invoice" button to load and click it
+    await page.waitForSelector( ".laskuhari-nappi.uusi-lasku" );
+    await functions.sleep( 2000 );
+    await page.click( ".laskuhari-nappi.uusi-lasku" );
+    await functions.sleep( 1000 );
+
+    // click "create invoice"
+    await page.click( "#laskuhari-create-only" );
+
+    // wait for page to load
+    await page.waitForSelector( ".laskuhari-payment-status" );
+
+    // open invoice pdf
+    await functions.open_invoice_pdf( page );
+
+    // wait for a while so we can assess the results
+    await functions.sleep( 10000 );
+
+    // close browser
+    await browser.close();
+}, 600000);

--- a/test/puppeteer/vat-percentages-multi.test.js
+++ b/test/puppeteer/vat-percentages-multi.test.js
@@ -1,0 +1,118 @@
+const puppeteer = require('puppeteer');
+const functions = require('./functions.js');
+const config    = require('./config.js');
+
+/**
+ * This test checks that the plugin supports
+ * different VAT percentages, including
+ * ones with decimals.
+ */
+
+test("vat-percentages-multi", async () => {
+    const browser = await puppeteer.launch({
+        headless: config.headless,
+        defaultViewport: {
+            width: 1452,
+            height: 768
+        },
+        args:[
+            '--start-maximized'
+        ]
+    });
+
+    const page = await browser.newPage();
+    await page.setDefaultNavigationTimeout( 60000 );
+
+    page.on("pageerror", function(err) {
+            theTempValue = err.toString();
+            console.log("Page error: " + theTempValue);
+            browser.close();
+    });
+
+    // log in to plugin settings page
+    await functions.open_settings( page );
+
+    // reset settings
+    await functions.reset_settings( page );
+
+    // save settings
+    await page.click( ".woocommerce-save-button" );
+
+    // go to new order creation
+    await page.goto( config.wordpress_url + "/wp-admin/post-new.php?post_type=shop_order" );
+
+    // change status of order
+    await page.waitForSelector( "#order_status" );
+    await page.select( "#order_status", "wc-processing" );
+
+    // click billing address edit button
+    await page.waitForSelector( ".order_data_column a.edit_address" );
+    await page.click( ".order_data_column a.edit_address" );
+
+    // input customer details
+    await page.waitForSelector( "#_billing_first_name" );
+    await page.click( "#_billing_first_name" );
+    await page.keyboard.type( "Jack VAT rates" );
+    await page.click( "#_billing_last_name" );
+    await page.keyboard.type( "Smith" );
+    await page.click( "#_billing_address_1" );
+    await page.keyboard.type( "Jack's road" );
+    await page.click( "#_billing_city" );
+    await page.keyboard.type( "Jackcity" );
+    await page.click( "#_billing_postcode" );
+    await page.keyboard.type( "54321" );
+    await page.evaluate(() => document.getElementById("_billing_email").value="");
+    await page.click( "#_billing_email" );
+    await page.keyboard.type( config.test_email );
+
+    // Add testing products
+    await functions.add_product_to_order( page, "VAT 25.5 test 1" );
+    await functions.add_product_to_order( page, "VAT 25.5 test 2" );
+    await functions.add_product_to_order( page, "VAT 14 test" );
+    await functions.add_product_to_order( page, "VAT conflict" );
+
+    // prepare for confirmation dialog
+    page.off('dialog', functions.accept_dialog);
+    page.on('dialog', functions.accept_dialog);
+
+    // click on "calculate"
+    await page.click( ".button.button-primary.calculate-action" );
+
+    // wait for changes to take effect
+    await functions.sleep( 3000 );
+
+    // create order
+    await page.click( ".button.save_order.button-primary" );
+    await functions.sleep( 3000 );
+
+    // wait for page to load
+    await page.waitForSelector( "#laskuhari_metabox" );
+
+    // check that invoice was not created
+    let element = await page.$('.laskuhari-tila');
+    let invoice_status = await page.evaluate(el => el.textContent, element);
+    expect( invoice_status ).toBe( "EI LASKUTETTU" );
+
+    await functions.sleep( 600 );
+
+    // wait for "create invoice" button to load and click it
+    await page.waitForSelector( ".laskuhari-nappi.uusi-lasku" );
+    await functions.sleep( 2000 );
+    await page.click( ".laskuhari-nappi.uusi-lasku" );
+    await functions.sleep( 1000 );
+
+    // click "create invoice"
+    await page.click( "#laskuhari-create-only" );
+
+    // wait for page to load
+    await page.waitForSelector( ".laskuhari-payment-status" );
+
+    // open invoice pdf
+    await functions.open_invoice_pdf( page );
+
+    // wait for a while so we can assess the results
+    await functions.sleep( 10000 );
+
+    // close browser
+    await browser.close();
+}, 600000);

--- a/test/puppeteer/vat-percentages-multi.test.js
+++ b/test/puppeteer/vat-percentages-multi.test.js
@@ -107,11 +107,17 @@ test("vat-percentages-multi", async () => {
     // wait for page to load
     await page.waitForSelector( ".laskuhari-payment-status" );
 
+    // get order id from url
+    const order_id = await functions.get_order_id( page );
+
     // open invoice pdf
     await functions.open_invoice_pdf( page );
 
     // wait for a while so we can assess the results
     await functions.sleep( 10000 );
+
+    // check amounts
+    await functions.check_invoice_amounts( page, order_id, 70.13, 12.13, 82.26 );
 
     // close browser
     await browser.close();

--- a/test/puppeteer/vat-percentages-with-coupons.test.js
+++ b/test/puppeteer/vat-percentages-with-coupons.test.js
@@ -1,0 +1,118 @@
+const puppeteer = require('puppeteer');
+const functions = require('./functions.js');
+const config    = require('./config.js');
+
+/**
+ * This test checks that the plugin supports coupons for
+ * multiple different VAT percentages on a single order.
+ */
+
+test("vat-percentages-with-coupons", async () => {
+    const browser = await puppeteer.launch({
+        headless: config.headless,
+        defaultViewport: {
+            width: 1452,
+            height: 768
+        },
+        args:[
+            '--start-maximized'
+        ]
+    });
+
+    const page = await browser.newPage();
+    await page.setDefaultNavigationTimeout( 60000 );
+
+    page.on("pageerror", function(err) {
+            theTempValue = err.toString();
+            console.log("Page error: " + theTempValue);
+            browser.close();
+    });
+
+    // log in to plugin settings page
+    await functions.open_settings( page );
+
+    // reset settings
+    await functions.reset_settings( page );
+
+    // save settings
+    await page.click( ".woocommerce-save-button" );
+
+    // go to new order creation
+    await page.goto( config.wordpress_url + "/wp-admin/post-new.php?post_type=shop_order" );
+
+    // change status of order
+    await page.waitForSelector( "#order_status" );
+    await page.select( "#order_status", "wc-processing" );
+
+    // click billing address edit button
+    await page.waitForSelector( ".order_data_column a.edit_address" );
+    await page.click( ".order_data_column a.edit_address" );
+
+    // input customer details
+    await page.waitForSelector( "#_billing_first_name" );
+    await page.click( "#_billing_first_name" );
+    await page.keyboard.type( "Jack VAT rates" );
+    await page.click( "#_billing_last_name" );
+    await page.keyboard.type( "Smith" );
+    await page.click( "#_billing_address_1" );
+    await page.keyboard.type( "Jack's road" );
+    await page.click( "#_billing_city" );
+    await page.keyboard.type( "Jackcity" );
+    await page.click( "#_billing_postcode" );
+    await page.keyboard.type( "54321" );
+    await page.evaluate(() => document.getElementById("_billing_email").value="");
+    await page.click( "#_billing_email" );
+    await page.keyboard.type( config.test_email );
+
+    // Add testing products
+    await functions.add_product_to_order( page, "VAT 25.5 test 1" );
+    await functions.add_product_to_order( page, "VAT 14 test" );
+
+    // Add coupon
+    await functions.add_coupon_to_order( page, "10off" );
+
+    // prepare for confirmation dialog
+    page.off('dialog', functions.accept_dialog);
+    page.on('dialog', functions.accept_dialog);
+
+    // click on "calculate"
+    await page.click( ".button.button-primary.calculate-action" );
+
+    // wait for changes to take effect
+    await functions.sleep( 3000 );
+
+    // create order
+    await page.click( ".button.save_order.button-primary" );
+    await functions.sleep( 3000 );
+
+    // wait for page to load
+    await page.waitForSelector( "#laskuhari_metabox" );
+
+    // check that invoice was not created
+    let element = await page.$('.laskuhari-tila');
+    let invoice_status = await page.evaluate(el => el.textContent, element);
+    expect( invoice_status ).toBe( "EI LASKUTETTU" );
+
+    await functions.sleep( 600 );
+
+    // wait for "create invoice" button to load and click it
+    await page.waitForSelector( ".laskuhari-nappi.uusi-lasku" );
+    await functions.sleep( 2000 );
+    await page.click( ".laskuhari-nappi.uusi-lasku" );
+    await functions.sleep( 1000 );
+
+    // click "create invoice"
+    await page.click( "#laskuhari-create-only" );
+
+    // wait for page to load
+    await page.waitForSelector( ".laskuhari-payment-status" );
+
+    // open invoice pdf
+    await functions.open_invoice_pdf( page );
+
+    // wait for a while so we can assess the results
+    await functions.sleep( 10000 );
+
+    // close browser
+    await browser.close();
+}, 600000);

--- a/test/puppeteer/vat-percentages-with-coupons.test.js
+++ b/test/puppeteer/vat-percentages-with-coupons.test.js
@@ -107,11 +107,17 @@ test("vat-percentages-with-coupons", async () => {
     // wait for page to load
     await page.waitForSelector( ".laskuhari-payment-status" );
 
+    // get order id from url
+    const order_id = await functions.get_order_id( page );
+
     // open invoice pdf
     await functions.open_invoice_pdf( page );
 
     // wait for a while so we can assess the results
     await functions.sleep( 10000 );
+
+    // check amounts
+    await functions.check_invoice_amounts( page, order_id, 54, 8.6, 62.6 );
 
     // close browser
     await browser.close();

--- a/test/puppeteer/vat-percentages-with-discounts.test.js
+++ b/test/puppeteer/vat-percentages-with-discounts.test.js
@@ -120,11 +120,17 @@ test("vat-percentages-with-discounts", async () => {
     // wait for page to load
     await page.waitForSelector( ".laskuhari-payment-status" );
 
+    // get order id from url
+    const order_id = await functions.get_order_id( page );
+
     // open invoice pdf
     await functions.open_invoice_pdf( page );
 
     // wait for a while so we can assess the results
     await functions.sleep( 10000 );
+
+    // check amounts
+    await functions.check_invoice_amounts( page, order_id, 30.95, 7.21, 38.16 );
 
     // close browser
     await browser.close();

--- a/test/puppeteer/vat-percentages-with-discounts.test.js
+++ b/test/puppeteer/vat-percentages-with-discounts.test.js
@@ -1,0 +1,131 @@
+const puppeteer = require('puppeteer');
+const functions = require('./functions.js');
+const config    = require('./config.js');
+
+/**
+ * This test checks that the plugin supports discounts for
+ * multiple different VAT percentages on a single order.
+ */
+
+test("vat-percentages-with-discounts", async () => {
+    const browser = await puppeteer.launch({
+        headless: config.headless,
+        defaultViewport: {
+            width: 1452,
+            height: 768
+        },
+        args:[
+            '--start-maximized'
+        ]
+    });
+
+    const page = await browser.newPage();
+    await page.setDefaultNavigationTimeout( 60000 );
+
+    page.on("pageerror", function(err) {
+            theTempValue = err.toString();
+            console.log("Page error: " + theTempValue);
+            browser.close();
+    });
+
+    // log in to plugin settings page
+    await functions.open_settings( page );
+
+    // reset settings
+    await functions.reset_settings( page );
+
+    // save settings
+    await page.click( ".woocommerce-save-button" );
+
+    // go to new order creation
+    await page.goto( config.wordpress_url + "/wp-admin/post-new.php?post_type=shop_order" );
+
+    // change status of order
+    await page.waitForSelector( "#order_status" );
+    await page.select( "#order_status", "wc-processing" );
+
+    // click billing address edit button
+    await page.waitForSelector( ".order_data_column a.edit_address" );
+    await page.click( ".order_data_column a.edit_address" );
+
+    // input customer details
+    await page.waitForSelector( "#_billing_first_name" );
+    await page.click( "#_billing_first_name" );
+    await page.keyboard.type( "Jack VAT rates" );
+    await page.click( "#_billing_last_name" );
+    await page.keyboard.type( "Smith" );
+    await page.click( "#_billing_address_1" );
+    await page.keyboard.type( "Jack's road" );
+    await page.click( "#_billing_city" );
+    await page.keyboard.type( "Jackcity" );
+    await page.click( "#_billing_postcode" );
+    await page.keyboard.type( "54321" );
+    await page.evaluate(() => document.getElementById("_billing_email").value="");
+    await page.click( "#_billing_email" );
+    await page.keyboard.type( config.test_email );
+
+    // Add testing products
+    await functions.add_product_to_order( page, "VAT 25.5 test 1" );
+    await functions.add_product_to_order( page, "VAT 14 test" );
+
+    // Go to edit mode for all products
+    let product_edit_buttons = await page.$$( ".edit-order-item" );
+    await product_edit_buttons[0].click();
+    await product_edit_buttons[1].click();
+    await functions.sleep( 100 );
+
+    // Set prices for products
+    await page.waitForSelector( ".line_total" );
+    let totals = await page.$$( ".line_total" );
+    await totals[0].evaluate(e => { e.value = "25"; });
+    await totals[1].evaluate(e => { e.value = "5,95"; });
+
+    // Save changes
+    await page.click( ".save-action" );
+    await functions.sleep( 3000 );
+
+    // prepare for confirmation dialog
+    page.off('dialog', functions.accept_dialog);
+    page.on('dialog', functions.accept_dialog);
+
+    // click on "calculate"
+    await page.click( ".button.button-primary.calculate-action" );
+
+    // wait for changes to take effect
+    await functions.sleep( 3000 );
+
+    // create order
+    await page.click( ".button.save_order.button-primary" );
+    await functions.sleep( 3000 );
+
+    // wait for page to load
+    await page.waitForSelector( "#laskuhari_metabox" );
+
+    // check that invoice was not created
+    let element = await page.$('.laskuhari-tila');
+    let invoice_status = await page.evaluate(el => el.textContent, element);
+    expect( invoice_status ).toBe( "EI LASKUTETTU" );
+
+    await functions.sleep( 600 );
+
+    // wait for "create invoice" button to load and click it
+    await page.waitForSelector( ".laskuhari-nappi.uusi-lasku" );
+    await functions.sleep( 2000 );
+    await page.click( ".laskuhari-nappi.uusi-lasku" );
+    await functions.sleep( 1000 );
+
+    // click "create invoice"
+    await page.click( "#laskuhari-create-only" );
+
+    // wait for page to load
+    await page.waitForSelector( ".laskuhari-payment-status" );
+
+    // open invoice pdf
+    await functions.open_invoice_pdf( page );
+
+    // wait for a while so we can assess the results
+    await functions.sleep( 10000 );
+
+    // close browser
+    await browser.close();
+}, 600000);

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -874,21 +874,28 @@ function laskuhari_sync_product_on_save( $product_id ) {
     }
 }
 
-function laskuhari_get_product_price( $product ) {
+/**
+ * Get the product price with and without tax
+ *
+ * @param WC_Product $product
+ * @param ?float $vat
+ * @return array<string, float>
+ */
+function laskuhari_get_product_price( $product, $vat = null ) {
     $prices_include_tax = get_option( 'woocommerce_prices_include_tax' ) == 'yes' ? true : false;
 
-    $vat = laskuhari_get_vat_rate( $product );
+    $vat = $vat ?? laskuhari_get_vat_rate( $product );
 
     $vat_multiplier = (100 + $vat) / 100;
 
     if( $prices_include_tax ) {
-        $price_with_tax = $product->get_regular_price( 'edit' );
+        $price_with_tax = (float) $product->get_regular_price( 'edit' );
         if( ! $price_with_tax ) {
             $price_with_tax = 0;
         }
         $price_without_tax = $price_with_tax / $vat_multiplier;
     } else {
-        $price_without_tax = $product->get_regular_price( 'edit' );
+        $price_without_tax = (float) $product->get_regular_price( 'edit' );
         if( ! $price_without_tax ) {
             $price_without_tax = 0;
         }
@@ -3356,7 +3363,7 @@ function laskuhari_process_action(
             $product_sku = $product->get_sku();
 
             if( $laskuhari_gateway_object->calculate_discount_percent ) {
-                $price = laskuhari_get_product_price( $product );
+                $price = laskuhari_get_product_price( $product, $alv );
 
                 $discount_percent = 0;
                 $discount_amount = 0;

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3303,7 +3303,17 @@ function laskuhari_process_action(
     foreach( $products as $item ) {
 
         $data = $item->get_data();
-        $tax_data = $item->get_taxes();
+
+        if( is_a( $item, WC_Order_Item_Product::class ) ) {
+            /** @var WC_Order_Item_Product $item */
+            $tax_data = $item->get_taxes();
+        } else {
+            Logger::enabled( 'notice' ) && Logger::log( sprintf(
+                'Laskuhari: Order item is not a product item, but a %s, order %d',
+                get_class( $item ),
+                $order_id,
+            ), 'notice' );
+        }
 
         if( isset( $tax_data['total'] ) ) {
             // Use the more accurate total tax (4DP) amount if available

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3201,8 +3201,8 @@ function laskuhari_process_action(
 
     // calculate shipping cost down to multiple decimals
     // get_shipping_total returns rounded excluding tax
-    $toimitus_veropros  = $toimitusmaksu != 0 ? round( $toimitus_vero / $toimitusmaksu, 2) : 0;
-    $toimitusmaksu      = round( $toimitusmaksu + $toimitus_vero, 2 ) / ( 1 + $toimitus_veropros );
+    $toimitus_veropros  = $toimitusmaksu != 0 ? laskuhari_vat_percent( $toimitus_vero / $toimitusmaksu * 100 ) : 0;
+    $toimitusmaksu      = round( $toimitusmaksu + $toimitus_vero, 2 ) / ( 1 + $toimitus_veropros / 100 );
 
     $cart_discount      = $order->get_discount_total();
     $cart_discount_tax  = $order->get_discount_tax();

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Laskuhari for WooCommerce
 Plugin URI: https://www.laskuhari.fi/woocommerce-laskutus
 Description: Lisää automaattilaskutuksen maksutavaksi WooCommerce-verkkokauppaan sekä mahdollistaa tilausten manuaalisen laskuttamisen
-Version: 1.11.2
+Version: 1.12.0
 Author: Datahari Solutions
 Author URI: https://www.datahari.fi
 License: GPLv2

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3370,7 +3370,10 @@ function laskuhari_process_action(
         if( $product_id ) {
             set_transient( "laskuhari_update_product_" . $product_id, $product_id, 4 );
             $product = wc_get_product( $product_id );
-            $product_sku = $product->get_sku();
+
+            if( is_object( $product ) ) {
+                $product_sku = $product->get_sku();
+            }
         }
 
         if( $laskuhari_gateway_object->calculate_discount_percent ) {

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3361,35 +3361,35 @@ function laskuhari_process_action(
             set_transient( "laskuhari_update_product_" . $product_id, $product_id, 4 );
             $product = wc_get_product( $product_id );
             $product_sku = $product->get_sku();
+        }
 
-            if( $laskuhari_gateway_object->calculate_discount_percent ) {
-                $price_with_tax = $data['subtotal'] + $tax_data['subtotal'];
-                $price_without_tax = $data['subtotal'];
+        if( $laskuhari_gateway_object->calculate_discount_percent ) {
+            $price_with_tax = $data['subtotal'] + $tax_data['subtotal'];
+            $price_without_tax = $data['subtotal'];
 
-                $discount_percent = 0;
-                $discount_amount = 0;
-                if( $price_without_tax != 0 ) {
-                    $discount_amount = $price_without_tax - $yks_veroton;
-                    $discount_percent = $discount_amount / $price_without_tax * 100;
-                }
+            $discount_percent = 0;
+            $discount_amount = 0;
+            if( $price_without_tax != 0 ) {
+                $discount_amount = $price_without_tax - $yks_veroton;
+                $discount_percent = $discount_amount / $price_without_tax * 100;
+            }
 
-                if( $discount_percent > 0.009 && $discount_amount > 0.009 ) {
-                    $ale = $discount_percent;
-                    if( $data["quantity"] != 0 ) {
-                        // Calculate price per unit so that it matches the rounded total price, tax included.
-                        // This avoids rounding differences between Laskuhari and WooCommerce.
-                        $yks_verollinen = round( $price_with_tax * $data['quantity'], 2 ) / $data['quantity'];
-                        $yks_veroton = $yks_verollinen / ( 1 + $alv / 100 );
+            if( $discount_percent > 0.009 && $discount_amount > 0.009 ) {
+                $ale = $discount_percent;
+                if( $data["quantity"] != 0 ) {
+                    // Calculate price per unit so that it matches the rounded total price, tax included.
+                    // This avoids rounding differences between Laskuhari and WooCommerce.
+                    $yks_verollinen = round( $price_with_tax * $data['quantity'], 2 ) / $data['quantity'];
+                    $yks_veroton = $yks_verollinen / ( 1 + $alv / 100 );
 
-                        $ale_maara_verollinen = $yks_verollinen * ($ale / 100);
-                        $yht_verollinen = ( $yks_verollinen - $ale_maara_verollinen ) * $data['quantity'];
+                    $ale_maara_verollinen = $yks_verollinen * ($ale / 100);
+                    $yht_verollinen = ( $yks_verollinen - $ale_maara_verollinen ) * $data['quantity'];
 
-                        $ale_maara_veroton = $yks_veroton * ($ale / 100);
-                        $yht_veroton = ( $yks_veroton - $ale_maara_veroton ) * $data['quantity'];
-                    } else {
-                        $yks_verollinen = 0;
-                        $yks_veroton = 0;
-                    }
+                    $ale_maara_veroton = $yks_veroton * ($ale / 100);
+                    $yht_veroton = ( $yks_veroton - $ale_maara_veroton ) * $data['quantity'];
+                } else {
+                    $yks_verollinen = 0;
+                    $yks_veroton = 0;
                 }
             }
         }

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3363,13 +3363,14 @@ function laskuhari_process_action(
             $product_sku = $product->get_sku();
 
             if( $laskuhari_gateway_object->calculate_discount_percent ) {
-                $price = laskuhari_get_product_price( $product, $alv );
+                $price_with_tax = $data['subtotal'] + $tax_data['subtotal'];
+                $price_without_tax = $data['subtotal'];
 
                 $discount_percent = 0;
                 $discount_amount = 0;
-                if( $price['price_without_tax'] != 0 ) {
-                    $discount_amount = $price['price_without_tax'] - $yks_veroton;
-                    $discount_percent = $discount_amount / $price['price_without_tax'] * 100;
+                if( $price_without_tax != 0 ) {
+                    $discount_amount = $price_without_tax - $yks_veroton;
+                    $discount_percent = $discount_amount / $price_without_tax * 100;
                 }
 
                 if( $discount_percent > 0.009 && $discount_amount > 0.009 ) {
@@ -3377,7 +3378,7 @@ function laskuhari_process_action(
                     if( $data["quantity"] != 0 ) {
                         // Calculate price per unit so that it matches the rounded total price, tax included.
                         // This avoids rounding differences between Laskuhari and WooCommerce.
-                        $yks_verollinen = round( $price["price_with_tax"] * $data['quantity'], 2 ) / $data['quantity'];
+                        $yks_verollinen = round( $price_with_tax * $data['quantity'], 2 ) / $data['quantity'];
                         $yks_veroton = $yks_verollinen / ( 1 + $alv / 100 );
 
                         $ale_maara_verollinen = $yks_verollinen * ($ale / 100);

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3329,6 +3329,9 @@ function laskuhari_process_action(
             $tax_data['subtotal'] = $data['subtotal_tax'];
         }
 
+        // For orders with coupons, we will use the non-discounted
+        // price for the invoice rows, since we will add the
+        // coupons as negative discount rows in the end
         if( $has_coupons ) {
             $sub = 'sub';
         } else {


### PR DESCRIPTION
### Added

- Support for the new 25.5 % VAT (and future VAT rates with decimals)
- End-to-end tests for orders with different VAT percentages
- End-to-end tests for checking that invoice amounts match order amounts

### Changed

- Coupon discounts are now added per VAT rate when order includes products with various VAT rates
- The product price of an order line item is now read directly from the item meta, not from the product database