### PR TITLE
Released version 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.14.0] 2025-06-19
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The filter `laskuhari_invoice_row_payload` now takes in more arguments (`?WC_Order_Item $item, int $order_id, string $type`) so invoice row information can be changed based on order details and row type
 - The filter `laskuhari_invoice_surcharge` now takes in more arguments (`float $order_subtotal, string $send_method, ?WC_Cart $cart, ?WC_Order $order, bool $includes_tax`) so that changes to the invoicing surcharge can be made based on order/cart details
 
+### Added
+
+- Nonce checking for invoice creation and sending actions to prevent accidental double invoicing
+
 ### Removed
 
 - Removed the filter `laskuhari_disable_invoice_surcharge`. The same behavior can be achieved now through `laskuhari_invoice_surcharge` by setting the surcharge to zero.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Coupons starting with an underscore are not added as a separate discount row
+- The filter `laskuhari_invoice_row_payload` now takes in more arguments (`?WC_Order_Item $item, int $order_id, string $type`) so invoice row information can be changed based on order details and row type
+- The filter `laskuhari_invoice_surcharge` now takes in more arguments (`float $order_subtotal, string $send_method, ?WC_Cart $cart, ?WC_Order $order, bool $includes_tax`) so that changes to the invoicing surcharge can be made based on order/cart details
+
+### Removed
+
+- Removed the filter `laskuhari_disable_invoice_surcharge`. The same behavior can be achieved now through `laskuhari_invoice_surcharge` by setting the surcharge to zero.
+
 ## [1.13.0] 2025-02-05
 
 ### Changed

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,10 +1,5 @@
 (function($) {
 	$(document).ready(function() {
-		$("body").on("click", "#doaction", function() {
-			if( $("#bulk-action-selector-top").val().indexOf("laskuhari") != -1 ) {
-				laskuhari_loading();
-			}
-		});
 		$("body").on("click", ".laskuhari-nappi.uusi-lasku", function() {
 			$('#laskuhari-laheta-lasku-lomake').slideUp();
 			$("#laskuhari-lahetystapa-lomake").appendTo( $("#lahetystapa-lomake2") );
@@ -36,14 +31,8 @@
 		$("body").on( "click", ".laskuhari-sidebutton-menu a", function() {
 			$("#"+$(this).closest(".laskuhari-sidebutton-menu").attr("id")).slideUp();
 		} );
-		$("body").on( "submit", "#posts-filter", function() {
-			if( $("#bulk-action-selector-top").val() === "laskuhari_batch_send" && ! confirm( "Haluatko varmasti luoda ja LÄHETTÄÄ laskut valituista tilauksista?" ) ) {
-				return false;
-			}
-			if( $("#bulk-action-selector-top").val() === "laskuhari_batch_create" && ! confirm( "Haluatko varmasti luoda laskut valituista tilauksista? (laskuja ei lähetetä)" ) ) {
-				return false;
-			}
-		} );
+		$("body").on( "submit", "#posts-filter", handle_laskuhari_action ); // legacy
+		$("body").on( "submit", "#wc-orders-filter", handle_laskuhari_action );
 		$("body").on( "click", ".lh-show-debug-summary", function() {
 			laskuhari_loading();
 			$.ajax({
@@ -156,6 +145,7 @@ function laskuhari_admin_action( action ) {
 
 	window.location.href = urli+
 		'laskuhari='+action+
+		'&_lhnonce='+encodeURIComponent(laskuhariInfo.nonce)+
 		'&laskuhari-laskutustapa='+encodeURIComponent(laskutustapa)+
 		'&laskuhari-maksuehto='+encodeURIComponent(maksuehto)+
 		'&laskuhari-ytunnus='+encodeURIComponent(ytunnus)+
@@ -182,5 +172,21 @@ function laskuhari_no_address_confirm_send( warning_email, warning_einvoice_lett
 	} else {
 		alert( warning_einvoice_letter );
 		return false;
+	}
+}
+
+function handle_laskuhari_action() {
+	const action = jQuery( "#bulk-action-selector-top" ).val();
+
+	if( action.indexOf( "laskuhari_batch_send" ) === 0 && ! confirm( "Haluatko varmasti luoda ja LÄHETTÄÄ laskut valituista tilauksista?" ) ) {
+		return false;
+	}
+
+	if( action.indexOf( "laskuhari_batch_create" ) === 0 && ! confirm( "Haluatko varmasti luoda laskut valituista tilauksista? (laskuja ei lähetetä)" ) ) {
+		return false;
+	}
+
+	if( action.indexOf( "laskuhari" ) === 0 ) {
+		laskuhari_loading();
 	}
 }

--- a/scripts/copy_local.sh
+++ b/scripts/copy_local.sh
@@ -2,7 +2,7 @@
 
 # copies local files to test environment wordpress installation
 
-cd "$(dirname "$BASH_SOURCE")"
+cd "$(dirname "$0")"
 
 sudo rsync -av --delete ../ ../test/assets/wordpress/wp-content/plugins/woocommerce-laskuhari-payment-gateway/ \
      --exclude="test/" \

--- a/scripts/create_local_package.sh
+++ b/scripts/create_local_package.sh
@@ -6,7 +6,7 @@
 #                                                                           #
 #############################################################################
 
-cd "$(dirname "$BASH_SOURCE")"
+cd "$(dirname "$0")"
 
 # if folder with git repository name already exists, quit
 # be cause we don't want to delete or overwrite anything!

--- a/scripts/create_package.sh
+++ b/scripts/create_package.sh
@@ -6,7 +6,7 @@
 #                                                                           #
 #############################################################################
 
-cd "$(dirname "$BASH_SOURCE")"
+cd "$(dirname "$0")"
 
 # if folder with git repository name already exists, quit
 # be cause we don't want to delete or overwrite anything!

--- a/scripts/phpcompatibility
+++ b/scripts/phpcompatibility
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd "$(dirname "$BASH_SOURCE")/../"
+cd "$(dirname "$0")/../"
 
 if [ -z "$1" ]; then
     VERSION=7.2

--- a/scripts/phpstan
+++ b/scripts/phpstan
@@ -1,3 +1,3 @@
 #!/bin/bash
-cd "$(dirname "$BASH_SOURCE")"
+cd "$(dirname "$0")"
 ../vendor/bin/phpstan analyze $@ -c ../config/phpstan.neon

--- a/src/Laskuhari_Nonce.php
+++ b/src/Laskuhari_Nonce.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * This class handles creation and verification of nonces
+ * for Laskuhari actions that should only be performed
+ * once to prevent double submissions.
+ */
+
+namespace Laskuhari;
+
+class Laskuhari_Nonce
+{
+    /**
+     * Create a nonce for Laskuhari actions.
+     *
+     * @return string
+     */
+    public static function create() {
+        return bin2hex( random_bytes( 4 ) );
+    }
+
+    /**
+     * Verifies the nonce for Laskuhari actions.
+     *
+     * @param ?string $nonce The nonce to verify. If null, it will use the nonce from the request.
+     * @return void
+     */
+    public static function verify( $nonce = null ) {
+        if( session_status() !== PHP_SESSION_ACTIVE ) {
+            session_start();
+        }
+
+        self::garbage_collect();
+
+        $nonce = $nonce ?? $_REQUEST['_lhnonce'] ?? null;
+
+        if( ! $nonce ) {
+            wp_die( __( "Vahvistuskoodi (nonce) puuttuu", "laskuhari" ) );
+        }
+
+        if(
+            isset( $_SESSION['laskuhari_nonces'][$nonce] ) &&
+            ( time() - $_SESSION['laskuhari_nonces'][$nonce] ) < HOUR_IN_SECONDS
+        ) {
+            wp_die( __( "Estetty kaksinkertainen tai vanhentunut toiminto", "laskuhari" ) );
+        }
+
+        $_SESSION['laskuhari_nonces'][$nonce] = time();
+    }
+
+    /**
+     * Garbage collect old nonces.
+     *
+     * @return void
+     */
+    public static function garbage_collect() {
+        if( session_status() !== PHP_SESSION_ACTIVE ) {
+            session_start();
+        }
+
+        if( ! isset( $_SESSION['laskuhari_nonces'] ) ) {
+            $_SESSION['laskuhari_nonces'] = [];
+        }
+
+        $now = time();
+
+        foreach( $_SESSION['laskuhari_nonces'] as $nonce => $timestamp ) {
+            if( ( $now - $timestamp ) > HOUR_IN_SECONDS ) {
+                unset( $_SESSION['laskuhari_nonces'][$nonce] );
+            }
+        }
+    }
+}

--- a/src/WC_Gateway_Laskuhari.php
+++ b/src/WC_Gateway_Laskuhari.php
@@ -1,6 +1,7 @@
 <?php
 namespace Laskuhari;
 
+use WC_Cart;
 use WC_Log_Handler_File;
 use WC_Order;
 use WC_Order_Item_Product;
@@ -480,37 +481,43 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
     /**
      * Get the invoicing fee without tax
      *
-     * @param bool $sis_alv
+     * @param bool $includes_tax
      * @param string $send_method
+     * @param float $order_subtotal
+     * @param ?WC_Cart $cart
+     * @param ?WC_Order $order
+     *
      * @return float
      */
-    public function veroton_laskutuslisa( $sis_alv, $send_method ) {
-        $laskutuslisa = apply_filters( "laskuhari_invoice_surcharge", $this->laskutuslisa, $send_method, $sis_alv );
-        $laskutuslisa = $this->parse_decimal( $laskutuslisa );
+    public function veroton_laskutuslisa( $includes_tax, $send_method, $order_subtotal, $cart, $order ) {
+        $laskutuslisa = $this->parse_decimal( $this->laskutuslisa );
 
-        if( $sis_alv ) {
-            return $laskutuslisa / ( 1 + $this->laskutuslisa_alv / 100 );
+        if( $includes_tax ) {
+            $laskutuslisa = $laskutuslisa / ( 1 + $this->laskutuslisa_alv / 100 );
         }
 
-        return floatval( $laskutuslisa );
+        return apply_filters( "laskuhari_invoice_surcharge", $laskutuslisa, $order_subtotal, $send_method, $cart, $order, $includes_tax );
     }
 
     /**
      * Get the invoicing fee with tax
      *
-     * @param bool $sis_alv
+     * @param bool $includes_tax
      * @param string $send_method
+     * @param float $order_subtotal
+     * @param ?WC_Cart $cart
+     * @param ?WC_Order $order
+     *
      * @return float
      */
-    public function verollinen_laskutuslisa( $sis_alv, $send_method ) {
-        $laskutuslisa = apply_filters( "laskuhari_invoice_surcharge", $this->laskutuslisa, $send_method, $sis_alv );
-        $laskutuslisa = $this->parse_decimal( $laskutuslisa );
+    public function verollinen_laskutuslisa( $includes_tax, $send_method, $order_subtotal, $cart, $order ) {
+        $laskutuslisa = $this->parse_decimal( $this->laskutuslisa );
 
-        if( $sis_alv ) {
-            return $laskutuslisa;
+        if( ! $includes_tax ) {
+            $laskutuslisa = $laskutuslisa * ( 1 + $this->laskutuslisa_alv / 100 );
         }
 
-        return $laskutuslisa * ( 1 + $this->laskutuslisa_alv / 100 );
+        return apply_filters( "laskuhari_invoice_surcharge", $laskutuslisa, $order_subtotal, $send_method, $cart, $order, $includes_tax );
     }
 
     /**

--- a/src/WC_Gateway_Laskuhari.php
+++ b/src/WC_Gateway_Laskuhari.php
@@ -496,7 +496,10 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
             $laskutuslisa = $laskutuslisa / ( 1 + $this->laskutuslisa_alv / 100 );
         }
 
-        return apply_filters( "laskuhari_invoice_surcharge", $laskutuslisa, $order_subtotal, $send_method, $cart, $order, $includes_tax );
+        $laskutuslisa = apply_filters( "laskuhari_invoice_surcharge", $laskutuslisa, $order_subtotal, $send_method, $cart, $order, $includes_tax );
+        $laskutuslisa = is_numeric( $laskutuslisa ) ? $laskutuslisa : 0;
+
+        return floatval( $laskutuslisa );
     }
 
     /**
@@ -517,7 +520,10 @@ class WC_Gateway_Laskuhari extends WC_Payment_Gateway {
             $laskutuslisa = $laskutuslisa * ( 1 + $this->laskutuslisa_alv / 100 );
         }
 
-        return apply_filters( "laskuhari_invoice_surcharge", $laskutuslisa, $order_subtotal, $send_method, $cart, $order, $includes_tax );
+        $laskutuslisa = apply_filters( "laskuhari_invoice_surcharge", $laskutuslisa, $order_subtotal, $send_method, $cart, $order, $includes_tax );
+        $laskutuslisa = is_numeric( $laskutuslisa ) ? $laskutuslisa : 0;
+
+        return floatval( $laskutuslisa );
     }
 
     /**

--- a/test/puppeteer/bulk-action.test.js
+++ b/test/puppeteer/bulk-action.test.js
@@ -42,7 +42,7 @@ test("bulk-actions", async () => {
     } );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();
@@ -159,7 +159,7 @@ test("bulk-actions", async () => {
     } );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();

--- a/test/puppeteer/bulk-action.test.js
+++ b/test/puppeteer/bulk-action.test.js
@@ -73,7 +73,7 @@ test("bulk-actions", async () => {
     await page.click( '.wp-list-table tbody .check-column [type=checkbox]' );
 
     // select bulk action "create"
-    await functions.set_field_value( page, "#bulk-action-selector-top", "laskuhari_batch_create" );
+    await functions.select_starting_with( page, "#bulk-action-selector-top", "laskuhari_batch_create" );
 
     // submit
     await page.click( "#doaction" );
@@ -128,7 +128,7 @@ test("bulk-actions", async () => {
     await page.click( '.wp-list-table tbody .check-column [type=checkbox]' );
 
     // select bulk action "send"
-    await functions.set_field_value( page, "#bulk-action-selector-top", "laskuhari_batch_send" );
+    await functions.select_starting_with( page, "#bulk-action-selector-top", "laskuhari_batch_send" );
 
     // submit
     await page.click( "#doaction" );
@@ -190,7 +190,7 @@ test("bulk-actions", async () => {
     await page.click( '.wp-list-table tbody .check-column [type=checkbox]' );
 
     // select bulk action "send"
-    await functions.set_field_value( page, "#bulk-action-selector-top", "laskuhari_batch_send" );
+    await functions.select_starting_with( page, "#bulk-action-selector-top", "laskuhari_batch_send" );
 
     // submit
     await page.click( "#doaction" );
@@ -242,7 +242,7 @@ test("bulk-actions", async () => {
     await page.click( '.wp-list-table tbody .check-column [type=checkbox]' );
 
     // select bulk action "create"
-    await functions.set_field_value( page, "#bulk-action-selector-top", "laskuhari_batch_create" );
+    await functions.select_starting_with( page, "#bulk-action-selector-top", "laskuhari_batch_create" );
 
     // submit
     await page.click( "#doaction" );

--- a/test/puppeteer/checkout-change-order-status-when-invoicing.test.js
+++ b/test/puppeteer/checkout-change-order-status-when-invoicing.test.js
@@ -47,7 +47,7 @@ test("checkout-change-order-status-when-invoicing", async () => {
     } );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();

--- a/test/puppeteer/checkout-create-and-send-as-attachment.test.js
+++ b/test/puppeteer/checkout-create-and-send-as-attachment.test.js
@@ -46,7 +46,7 @@ test("checkout-create-and-send-as-attachment", async () => {
     } );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();

--- a/test/puppeteer/checkout-create-and-send.test.js
+++ b/test/puppeteer/checkout-create-and-send.test.js
@@ -45,7 +45,7 @@ test("checkout-create-and-send", async () => {
     } );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();

--- a/test/puppeteer/checkout-create-dont-send.test.js
+++ b/test/puppeteer/checkout-create-dont-send.test.js
@@ -45,7 +45,7 @@ test("checkout-create-dont-send", async () => {
     } );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();

--- a/test/puppeteer/checkout-disable-sending-methods.test.js
+++ b/test/puppeteer/checkout-disable-sending-methods.test.js
@@ -46,7 +46,7 @@ test("checkout-disable-sending-methods", async () => {
     } );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();
@@ -76,7 +76,7 @@ test("checkout-disable-sending-methods", async () => {
     } );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();
@@ -106,7 +106,7 @@ test("checkout-disable-sending-methods", async () => {
     } );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();

--- a/test/puppeteer/checkout-dont-create-dont-send.test.js
+++ b/test/puppeteer/checkout-dont-create-dont-send.test.js
@@ -45,7 +45,7 @@ test("checkout-dont-create-dont-send", async () => {
     } );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();

--- a/test/puppeteer/checkout-einvoice.test.js
+++ b/test/puppeteer/checkout-einvoice.test.js
@@ -45,7 +45,7 @@ test("checkout-einvoice", async () => {
     } );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();

--- a/test/puppeteer/checkout-letter.test.js
+++ b/test/puppeteer/checkout-letter.test.js
@@ -45,7 +45,7 @@ test("checkout-letter", async () => {
     } );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();

--- a/test/puppeteer/checkout-only-for-billing-customers.test.js
+++ b/test/puppeteer/checkout-only-for-billing-customers.test.js
@@ -40,7 +40,7 @@ test("checkout-only-for-billing-customers", async () => {
     await functions.sleep( 2000 );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();
@@ -75,7 +75,7 @@ test("checkout-only-for-billing-customers", async () => {
     await functions.sleep( 2000 );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();
@@ -110,7 +110,7 @@ test("checkout-only-for-billing-customers", async () => {
     await functions.sleep( 2000 );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();

--- a/test/puppeteer/checkout-with-invoicing-fee.test.js
+++ b/test/puppeteer/checkout-with-invoicing-fee.test.js
@@ -47,7 +47,7 @@ test("checkout-with-invoicing-fee", async () => {
     } );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();

--- a/test/puppeteer/checkout-with-paytrail-with-attachment.test.js
+++ b/test/puppeteer/checkout-with-paytrail-with-attachment.test.js
@@ -52,7 +52,7 @@ test("checkout-with-paytrail", async () => {
     } );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();

--- a/test/puppeteer/checkout-with-paytrail-without-attachment.test.js
+++ b/test/puppeteer/checkout-with-paytrail-without-attachment.test.js
@@ -51,7 +51,7 @@ test("checkout-with-paytrail", async () => {
     } );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();

--- a/test/puppeteer/checkout-with-paytrail.test.js
+++ b/test/puppeteer/checkout-with-paytrail.test.js
@@ -52,7 +52,7 @@ test("checkout-with-paytrail", async () => {
     } );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // wait for settings to be saved
     await page.waitForNavigation();

--- a/test/puppeteer/functions.js
+++ b/test/puppeteer/functions.js
@@ -398,3 +398,19 @@ exports.set_field_value = async function( page, selector, text ) {
         await element.type( text );
     }
 }
+
+// Selects an option of a select box whose value starts with text
+exports.select_starting_with = async function( page, selector, text ) {
+    let element = await page.waitForSelector( selector, {
+        visible: true
+    } );
+    let options = await element.$$('option');
+    for( const option of options ) {
+        let value = await page.evaluate( el => el.value, option );
+        if( value.startsWith( text ) ) {
+            element.select( value );
+            return;
+        }
+    }
+    throw new Error( "No option found starting with: " + text );
+}

--- a/test/puppeteer/functions.js
+++ b/test/puppeteer/functions.js
@@ -272,6 +272,14 @@ exports.reset_settings = async function( page ) {
     } );
 }
 
+exports.save_settings = async function( page ) {
+    await page.evaluate( function() {
+        let $ = jQuery;
+        $(".woocommerce-save-button").prop( "disabled", false );
+    } );
+    await page.click( ".woocommerce-save-button" );
+}
+
 exports.add_coupon_to_order = async function( page, coupon_code ) {
     const set_coupon_code = dialog => {
         dialog.accept( coupon_code );

--- a/test/puppeteer/manual-order.test.js
+++ b/test/puppeteer/manual-order.test.js
@@ -39,7 +39,7 @@ test("manual-order", async () => {
     await functions.reset_settings( page );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // create manual order
     await functions.create_manual_order( page, "manual-create-send-create-and-send" );

--- a/test/puppeteer/quantity-units.test.js
+++ b/test/puppeteer/quantity-units.test.js
@@ -35,7 +35,7 @@ test("quantity-units", async () => {
     await functions.reset_settings( page );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // go to new order creation
     await page.goto( config.wordpress_url + "/wp-admin/post-new.php?post_type=shop_order" );

--- a/test/puppeteer/rounding-issues-2.test.js
+++ b/test/puppeteer/rounding-issues-2.test.js
@@ -41,7 +41,7 @@ test("rounding-issues-2", async () => {
     await functions.reset_settings( page );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // go to new order creation
     await page.goto( config.wordpress_url + "/wp-admin/post-new.php?post_type=shop_order" );

--- a/test/puppeteer/rounding-issues.test.js
+++ b/test/puppeteer/rounding-issues.test.js
@@ -41,7 +41,7 @@ test("rounding-issues", async () => {
     await functions.reset_settings( page );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // go to new order creation
     await page.goto( config.wordpress_url + "/wp-admin/post-new.php?post_type=shop_order" );

--- a/test/puppeteer/row-amounts.test.js
+++ b/test/puppeteer/row-amounts.test.js
@@ -35,7 +35,7 @@ test("row-amounts", async () => {
     await functions.reset_settings( page );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // go to new order creation
     await page.goto( config.wordpress_url + "/wp-admin/post-new.php?post_type=shop_order" );

--- a/test/puppeteer/vat-percentages-25.5.test.js
+++ b/test/puppeteer/vat-percentages-25.5.test.js
@@ -35,7 +35,7 @@ test("vat-percentages-25.5", async () => {
     await functions.reset_settings( page );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // go to new order creation
     await page.goto( config.wordpress_url + "/wp-admin/post-new.php?post_type=shop_order" );

--- a/test/puppeteer/vat-percentages-multi.test.js
+++ b/test/puppeteer/vat-percentages-multi.test.js
@@ -36,7 +36,7 @@ test("vat-percentages-multi", async () => {
     await functions.reset_settings( page );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // go to new order creation
     await page.goto( config.wordpress_url + "/wp-admin/post-new.php?post_type=shop_order" );

--- a/test/puppeteer/vat-percentages-with-coupons.test.js
+++ b/test/puppeteer/vat-percentages-with-coupons.test.js
@@ -35,7 +35,7 @@ test("vat-percentages-with-coupons", async () => {
     await functions.reset_settings( page );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // go to new order creation
     await page.goto( config.wordpress_url + "/wp-admin/post-new.php?post_type=shop_order" );

--- a/test/puppeteer/vat-percentages-with-discounts.test.js
+++ b/test/puppeteer/vat-percentages-with-discounts.test.js
@@ -35,7 +35,7 @@ test("vat-percentages-with-discounts", async () => {
     await functions.reset_settings( page );
 
     // save settings
-    await page.click( ".woocommerce-save-button" );
+    await functions.save_settings( page );
 
     // go to new order creation
     await page.goto( config.wordpress_url + "/wp-admin/post-new.php?post_type=shop_order" );

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3,7 +3,7 @@
 Plugin Name: Laskuhari for WooCommerce
 Plugin URI: https://www.laskuhari.fi/woocommerce-laskutus
 Description: Lisää automaattilaskutuksen maksutavaksi WooCommerce-verkkokauppaan sekä mahdollistaa tilausten manuaalisen laskuttamisen
-Version: 1.13.0
+Version: 1.14.0
 Author: Datahari Solutions
 Author URI: https://www.datahari.fi
 License: GPLv2

--- a/woocommerce-laskuhari-payment-gateway.php
+++ b/woocommerce-laskuhari-payment-gateway.php
@@ -3587,12 +3587,13 @@ function laskuhari_process_action(
     }
 
     $coupon_codes = $order->get_coupon_codes();
-    $has_coupons = count( $coupon_codes ) > 0;
 
     // remove coupons starting with an underscore
     $coupon_codes = array_filter( $coupon_codes, function($v) {
         return $v[0] !== '_';
     } );
+
+    $has_coupons = count( $coupon_codes ) > 0;
 
     // Cart discounts by VAT rate (key is VAT rate, value is sum, incl. tax)
     $cart_discounts = [];


### PR DESCRIPTION
### Changed

- Coupons starting with an underscore are not added as a separate discount row
- The filter `laskuhari_invoice_row_payload` now takes in more arguments (`?WC_Order_Item $item, int $order_id, string $type`) so invoice row information can be changed based on order details and row type
- The filter `laskuhari_invoice_surcharge` now takes in more arguments (`float $order_subtotal, string $send_method, ?WC_Cart $cart, ?WC_Order $order, bool $includes_tax`) so that changes to the invoicing surcharge can be made based on order/cart details

### Added

- Nonce checking for invoice creation and sending actions to prevent accidental double invoicing

### Removed

- Removed the filter `laskuhari_disable_invoice_surcharge`. The same behavior can be achieved now through `laskuhari_invoice_surcharge` by setting the surcharge to zero.